### PR TITLE
Archive source jars and javadoc jars

### DIFF
--- a/mats-websockets/client/dart/lib/src/MatsSocket.dart
+++ b/mats-websockets/client/dart/lib/src/MatsSocket.dart
@@ -26,7 +26,6 @@ String randomId([int length]) {
   return result;
 }
 
-/// Checks if you are awesome. Spoiler: you are.
 class MatsSocket {
   String appName;
   String appVersion;
@@ -148,7 +147,7 @@ class MatsSocket {
       var url = wsUrls[_nextUrlIndex];
       _log.info(
           'WebSocket not connected, connecting to url ${_nextUrlIndex} -> ${url}');
-      _websocketChannel = await socketFactory.connect(url, 'matssocket');
+      _websocketChannel = await socketFactory.connect(url, 'matssocket', authorization.token);
       _websocketChannelDone = Completer();
       _nextUrlIndex = (_nextUrlIndex + 1) % wsUrls.length;
 
@@ -435,7 +434,7 @@ class MatsSocket {
 /// It should return a new instance of a WebSocketChannel for the current platform.
 abstract class WebSocketChannelFactory {
   /// Connect to a WebSocketChannel
-  Future<WebSocketChannel> connect(String url, String protocol);
+  Future<WebSocketChannel> connect(String url, String protocol, String authorization);
 }
 
 // ======== Exceptions =============================================================================

--- a/mats-websockets/client/dart/test/integration.dart
+++ b/mats-websockets/client/dart/test/integration.dart
@@ -9,26 +9,37 @@ import 'dart:io';
 import 'logging.dart';
 
 class IOSocketFactory extends WebSocketChannelFactory {
-  Future<WebSocketChannel> connect(String url, String protocol) async {
-    return IOWebSocketChannel.connect(url, protocols: [protocol], headers: {}, pingInterval: Duration(seconds: 10));
+  Future<WebSocketChannel> connect(
+      String url, String protocol, String authorization) async {
+    return IOWebSocketChannel.connect(url,
+        protocols: [protocol],
+        headers: {'Authorization': 'Bearer $authorization'},
+        pingInterval: Duration(seconds: 10));
   }
 }
 
-void setAuth(MatsSocket matsSocket, {Duration duration = const Duration(minutes: 1), Duration roomForLatencyMillis = const Duration(seconds: 10)}) {
+void setAuth(MatsSocket matsSocket,
+    {Duration duration = const Duration(minutes: 1),
+    Duration roomForLatencyMillis = const Duration(seconds: 10)}) {
   var now = DateTime.now();
   var expiry = now.add(duration);
-  matsSocket.setCurrentAuthorization('DummyAuth:${expiry.millisecondsSinceEpoch}', expiry, roomForLatency: roomForLatencyMillis);
+  matsSocket.setCurrentAuthorization(
+      'DummyAuth:${expiry.millisecondsSinceEpoch}', expiry,
+      roomForLatency: roomForLatencyMillis);
 }
 
 final log = Logger('Test');
 
 void main() {
-
   configureLogging();
 
   final log = Logger('Test');
   DateTime testStart;
-  var urls = Platform.environment['MATS_SOCKET_URLS']?.split(",") ?? ['ws://localhost:8080/matssocket', 'ws://localhost:8081/matssocket'];
+  var urls = Platform.environment['MATS_SOCKET_URLS']?.split(",") ??
+      [
+        'ws://localhost:8080/matssocket/json',
+        'ws://localhost:8081/matssocket/json'
+      ];
   var matsSocket = MatsSocket('Test', '1.0', urls, IOSocketFactory());
   setUp(() {
     testStart = DateTime.now();
@@ -36,11 +47,11 @@ void main() {
   });
   tearDown(() async {
     await matsSocket.closeSession('testDone');
-    log.info('=== Test [${Invoker.current.liveTest.test.name}] done after [${DateTime.now().difference(testStart)}]');
+    log.info(
+        '=== Test [${Invoker.current.liveTest.test.name}] done after [${DateTime.now().difference(testStart)}]');
   });
 
   group('Authorization', () {
-
     test('Should invoke authorization callback before making calls', () async {
       var authCallbackCalled = false;
       matsSocket.setAuthorizationExpiredCallback((event) {
@@ -48,23 +59,23 @@ void main() {
         setAuth(matsSocket);
       });
 
-      await matsSocket.send('Test.single', 'SEND_' + randomId(6),{});
+      await matsSocket.send('Test.single', 'SEND_' + randomId(6), {});
       expect(authCallbackCalled, true);
     });
 
-    test('Should not invoke authorization callback if authorization present', () async {
+    test('Should not invoke authorization callback if authorization present',
+        () async {
       var authCallbackCalled = false;
       setAuth(matsSocket);
       matsSocket.setAuthorizationExpiredCallback((event) {
         authCallbackCalled = true;
       });
 
-      await matsSocket.send('Test.single', 'SEND_' + randomId(6),{});
+      await matsSocket.send('Test.single', 'SEND_' + randomId(6), {});
       expect(authCallbackCalled, false);
     });
 
     test('Should invoke authorization callback when expired', () async {
-
       var authCallbackCalled = false;
 
       setAuth(matsSocket, duration: Duration(minutes: -10));
@@ -73,11 +84,12 @@ void main() {
         setAuth(matsSocket);
       });
 
-      await matsSocket.send('Test.single', 'SEND_' + randomId(6),{});
+      await matsSocket.send('Test.single', 'SEND_' + randomId(6), {});
       expect(authCallbackCalled, true);
     });
 
-    test('Should invoke authorization callback when room for latency expired', () async {
+    test('Should invoke authorization callback when room for latency expired',
+        () async {
       var authCallbackCalled = false;
 
       setAuth(matsSocket, roomForLatencyMillis: Duration(minutes: 10));
@@ -86,7 +98,7 @@ void main() {
         setAuth(matsSocket);
       });
 
-      await matsSocket.send('Test.single', 'SEND_' + randomId(6),{});
+      await matsSocket.send('Test.single', 'SEND_' + randomId(6), {});
       expect(authCallbackCalled, true);
     });
   });
@@ -99,21 +111,28 @@ void main() {
 
     test('Should have a promise that resolves when received', () async {
       var matsSocket = authenticatedMatsSocket();
-      var received = await matsSocket.send('Test.single', 'SEND_${randomId(6)}', {});
+      var received =
+          await matsSocket.send('Test.single', 'SEND_${randomId(6)}', {});
     });
   });
 
   group('request', () {
     test('Should receive a reply', () async {
       var matsSocket = authenticatedMatsSocket();
-      var reply = await matsSocket.request('Test.single', 'REQUEST-with-Promise_${randomId(6)}', {'string': 'Request String', 'number': e});
+      var reply = await matsSocket.request(
+          'Test.single',
+          'REQUEST-with-Promise_${randomId(6)}',
+          {'string': 'Request String', 'number': e});
       expect(reply.traceId, isNotNull);
     });
 
     test('Should invoke the ack callback', () async {
       var matsSocket = authenticatedMatsSocket();
       var receiveCallbackCalled = false;
-      await matsSocket.request('Test.single', 'REQUEST-with-Promise_${randomId(6)}', {'string': 'Request String', 'number': e}, (received) {
+      await matsSocket.request(
+          'Test.single',
+          'REQUEST-with-Promise_${randomId(6)}',
+          {'string': 'Request String', 'number': e}, (received) {
         receiveCallbackCalled = true;
       });
       expect(receiveCallbackCalled, equals(true));
@@ -126,16 +145,24 @@ void main() {
 
       var endpoint = matsSocket.endpoint('ClientSide.testEndpoint');
 
-      matsSocket.requestReplyTo('Test.single', 'REQUEST-with-Promise_${randomId(6)}', {'string': 'Request String', 'number': e}, 'ClientSide.testEndpoint');
+      await matsSocket.requestReplyTo(
+          'Test.single',
+          'REQUEST-with-Promise_${randomId(6)}',
+          {'string': 'Request String', 'number': e},
+          'ClientSide.testEndpoint');
       var reply = await endpoint.first;
       expect(reply.traceId, isNotNull);
     });
-
   });
 }
 
 MatsSocket authenticatedMatsSocket() {
-  var matsSocket = MatsSocket('Test', '1.0', ['ws://localhost:8080/matssocket', 'ws://localhost:8081/matssocket'], IOSocketFactory());
+  var urls = Platform.environment['MATS_SOCKET_URLS']?.split(",") ??
+      [
+        'ws://localhost:8080/matssocket/json',
+        'ws://localhost:8081/matssocket/json'
+      ];
+  var matsSocket = MatsSocket('Test', '1.0', urls, IOSocketFactory());
 
   setAuth(matsSocket);
   return matsSocket;

--- a/mats-websockets/client/dart/test/mock_socket_channel.dart
+++ b/mats-websockets/client/dart/test/mock_socket_channel.dart
@@ -95,7 +95,7 @@ class MockSocketFactory extends WebSocketChannelFactory {
     }
   });
 
-  Future<WebSocketChannel> connect(String url, String protocol) async {
+  Future<WebSocketChannel> connect(String url, String protocol, String authorization) async {
     print('Connecting');
     var channel = MockWebSocketChannel(url, protocol);
     channel.mockWebSocketSink.streamController.stream.expand((payload) {


### PR DESCRIPTION
When running ./gradlew install, javadoc and sourcejars are not installed in the local maven repository. This means that the source jars would not be available in other projects locally. When enabling javadoc for install, several javadoc warnings and errors where found. Most of these have been corrected except for where arguments and return values are missing. The javadoc command has been tweaked to also exclude missing attributes from the linting options.

Another warning comes from gradle, where the wrapper task is a deprecated name. This might cause incompatibilities with gradle 5.0. The gradle wrappers are already present in the project, so it's less of an issue that this task is now called generateWrapper instead of just wrapper.