### PR TITLE
Fixed issue where empty Optional was accessed.

### DIFF
--- a/mats-websockets/src/main/java/com/stolsvik/mats/websocket/impl/DefaultMatsSocketServer.java
+++ b/mats-websockets/src/main/java/com/stolsvik/mats/websocket/impl/DefaultMatsSocketServer.java
@@ -411,10 +411,10 @@ public class DefaultMatsSocketServer implements MatsSocketServer {
             // Do forward of notification - it will handle if we're the node being registered.
             notifyHomeNodeIfAnyAboutNewMessage(matsSocketSessionId);
         }
-
-        // ----- We have determined that MatsSocketSession has home here
-
-        _messageToWebSocketForwarder.notifyMessageFor(localMatsSocketSession.get());
+        else {
+            // ----- We have determined that MatsSocketSession has home here
+            _messageToWebSocketForwarder.notifyMessageFor(localMatsSocketSession.get());
+        }
     }
 
     void notifyHomeNodeIfAnyAboutNewMessage(String matsSocketSessionId) {


### PR DESCRIPTION
After we check if the Optional session is present, the code would always
try to get the content's regardless. Fixes this so we only access the
Optional when it's present.