### PR TITLE
Fix issue where messages where sent after session close.

### DIFF
--- a/mats-websockets/client/dart/.gitignore
+++ b/mats-websockets/client/dart/.gitignore
@@ -1,0 +1,11 @@
+# Files and directories created by pub
+.dart_tool/
+.packages
+# Remove the following pattern if you wish to check in your lock file
+pubspec.lock
+
+# Conventional directory for build outputs
+build/
+
+# Directory created by dartdoc
+doc/api/

--- a/mats-websockets/src/main/java/com/stolsvik/mats/websocket/impl/MatsSocketSession.java
+++ b/mats-websockets/src/main/java/com/stolsvik/mats/websocket/impl/MatsSocketSession.java
@@ -163,6 +163,7 @@ class MatsSocketSession implements Whole<String> {
                     // Any remaining messages will be rejected..
                     allMessagesReceivedFailSubtype = "ERROR";
                     allMessagesReceivedFailDescription = "Client just closed the session!";
+                    continue;
                 }
 
                 // ----- We do NOT KNOW whether we're authenticated!


### PR DESCRIPTION
When the session closes, we should not send an acknowledge of this
message back to the client, as we assume it is already disconnecting.

Change-Id: I86442afc827cc7fa77da05396ef38fd9fef53d0c