### PR TITLE
TECHNICAL: Fixed build issue with javascript tests.

### DIFF
--- a/mats-websockets/javascript.gradle
+++ b/mats-websockets/javascript.gradle
@@ -22,7 +22,7 @@ task yarnInstall(type: YarnTask) {
 
 // Task to start a MatsTestWebsocketServer for integration tests. We will monitor the log until we get the expected number
 // of ws urls, that other tasks can then depend on
-task startMatsTestWebsocketServer(dependsOn: [configurations.testRuntimeClasspath]) {
+task startMatsTestWebsocketServer(dependsOn: [configurations.testRuntimeClasspath, compileTestJava]) {
     ext {
         wsUrls = []
     }


### PR DESCRIPTION
The JavaScript tests starts a server based on the code in the test
folder of this project. For this to run, we need to compile all
dependent projects, and this projects test classes. This so that
all the jars and classes we depen on are compiled. The previous commit
ommitted the compilation of the test classes.

Also added a commit-msg hook in CONTRIBUTE that can be used to
automatically sign all commits. This is based on the Gerrit commit-msg
hook, but instead adds a fixed string in accordance with the SCA.

I contribute this material in accordance with the signed SCA.