### PR TITLE
Added Dart client for MatsSocket

### DIFF
--- a/mats-websockets/build.gradle
+++ b/mats-websockets/build.gradle
@@ -115,3 +115,4 @@ task stopMatsTestWebsocketServer(dependsOn: startMatsTestWebsocketServer) {
 startMatsTestWebsocketServer.finalizedBy(stopMatsTestWebsocketServer)
 
 apply from: 'javascript.gradle'
+apply from: 'dart.gradle'

--- a/mats-websockets/build.gradle
+++ b/mats-websockets/build.gradle
@@ -1,9 +1,10 @@
+import java.nio.charset.StandardCharsets
+import java.time.LocalDateTime
+
 // mats-websockets
 plugins {
     id "com.github.node-gradle.node" version "2.1.1"
 }
-
-apply from: 'javascript.gradle'
 
 dependencies {
     // Uses the mats-lib project
@@ -41,3 +42,76 @@ dependencies {
     testCompile "org.slf4j:log4j-over-slf4j:1.7.+"
     testCompile "ch.qos.logback:logback-classic:1.2.+"
 }
+
+// Task to start a MatsTestWebsocketServer for integration tests. We will monitor the log until we get the expected number
+// of ws urls, that other tasks can then depend on
+task startMatsTestWebsocketServer(dependsOn: [configurations.testRuntimeClasspath, compileTestJava]) {
+    ext {
+        wsUrls = []
+    }
+
+    doLast {
+        String serverClassname = "com.stolsvik.mats.websocket.MatsTestWebsocketServer";
+        logger.info("Starting MatsTestWebsocketServer");
+        List<String> cmd = [
+                "${System.getenv("JAVA_HOME")}/bin/java",
+                "-classpath", sourceSets.test.runtimeClasspath.asPath,
+                serverClassname,
+                "3"
+        ]
+        Process server = cmd.execute()
+
+        // Keep a log file of the server output
+        File log = new File("$buildDir/logs/matsSocketServer-${LocalDateTime.now().withNano(0)}.log")
+        log.parentFile.mkdirs();
+
+        BufferedReader reader = new BufferedReader(new InputStreamReader(server.inputStream, StandardCharsets.UTF_8));
+        log.withWriterAppend { out ->
+            String line;
+            while (wsUrls.size < 3 && (line = reader.readLine()) != null) {
+                out.writeLine(line)
+                int urlStart = line.indexOf("WS_URL: ")
+                int urlEnd = line.indexOf("json")
+                if (urlStart > -1 && urlEnd > urlStart) {
+                    String url = line.substring(urlStart + 8, urlEnd + 4)
+                    wsUrls.add(url)
+                    logger.info("Registering WS URL: $url");
+                }
+            }
+        }
+        if (wsUrls.isEmpty()) {
+            server.errorStream.eachLine { logger.error(it) }
+            logger.error("Failed to execute: [${cmd.join(" ")}]")
+            throw new GradleException("Failed to start $serverClassname, check log above for command.");
+        }
+        logger.info("$serverClassname started");
+
+        // Fork a new thread to just keep reading and logging the MatsTestWebsocketServer
+        new Thread({
+            log.withWriterAppend { out ->
+                reader.eachLine { line ->
+                    out.writeLine(line)
+                }
+            }
+        }, "MatsTestWebsocketServer-logprinter").start()
+    }
+}
+
+// Stop the MatsTestWebsocketServer, this is done by inspecting the wsUrls field on the start task,
+// and creating a url to the shutdown page based on the first websocket url. The shutdown page is
+// a servlet that will do System.exit(0) to shutdown the server.
+task stopMatsTestWebsocketServer(dependsOn: startMatsTestWebsocketServer) {
+    doLast {
+        String shutdownUrl = startMatsTestWebsocketServer.wsUrls[0]
+                .replace("ws://", "http://")
+                .replace("/matssocket/json", "/shutdown");
+        logger.info("Shutting down MatsTestWebsocketServer by invoking '$shutdownUrl")
+        String response = new URL(shutdownUrl).text;
+        logger.info("Response: '${response}'")
+    }
+}
+
+// Make sure that the startMatsTestWebsocketServer is finalized and shut down.
+startMatsTestWebsocketServer.finalizedBy(stopMatsTestWebsocketServer)
+
+apply from: 'javascript.gradle'

--- a/mats-websockets/client/dart/README.md
+++ b/mats-websockets/client/dart/README.md
@@ -1,0 +1,1 @@
+MatsSocket client in Dart.

--- a/mats-websockets/client/dart/analysis_options.yaml
+++ b/mats-websockets/client/dart/analysis_options.yaml
@@ -1,0 +1,14 @@
+# Defines a default set of lint rules enforced for
+# projects at Google. For details and rationale,
+# see https://github.com/dart-lang/pedantic#enabled-lints.
+include: package:pedantic/analysis_options.yaml
+
+# For lint rules and documentation, see http://dart-lang.github.io/linter/lints.
+# Uncomment to specify additional rules.
+# linter:
+#   rules:
+#     - camel_case_types
+
+analyzer:
+#   exclude:
+#     - path/to/excluded/files/**

--- a/mats-websockets/client/dart/lib/mats_socket.dart
+++ b/mats-websockets/client/dart/lib/mats_socket.dart
@@ -1,0 +1,6 @@
+/// Support for doing something awesome.
+///
+/// More dartdocs go here.
+library mats_socket;
+
+export 'src/MatsSocket.dart';

--- a/mats-websockets/client/dart/lib/src/MatsSocket.dart
+++ b/mats-websockets/client/dart/lib/src/MatsSocket.dart
@@ -1,0 +1,666 @@
+import 'dart:async';
+import 'dart:math';
+import 'dart:io';
+import 'dart:convert';
+
+import 'package:web_socket_channel/web_socket_channel.dart';
+import 'package:logging/logging.dart';
+
+DateTime EPOCH = DateTime.fromMicrosecondsSinceEpoch(0);
+const ALPHABET =
+    '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
+const CLIENT_LIB_NAME_AND_VERSION = 'MatsSocket.dart,v0.8.9';
+final VERSION =
+    '${CLIENT_LIB_NAME_AND_VERSION}; User-Agent: Dart ${Platform.version}';
+
+typedef AuthorizationCallback = Function(AuthorizationRefreshEvent);
+
+/// Generate a random id of the given length
+///
+String randomId([int length]) {
+  var rnd = Random();
+  var result = '';
+  for (var i = 0; i < length ?? 10; i++) {
+    result += ALPHABET[rnd.nextInt(ALPHABET.length)];
+  }
+  return result;
+}
+
+/// Checks if you are awesome. Spoiler: you are.
+class MatsSocket {
+  String appName;
+  String appVersion;
+  List<String> wsUrls;
+  WebSocketChannelFactory socketFactory;
+
+  // :: Authorization and session variables
+  String sessionId;
+  AuthorizationCallback _authorizationCallback;
+  Completer<Authorization> _authorizationCompleter;
+  Authorization _authorization;
+
+  // :: Message pipeline variables
+  int pipelineMaxSize = 25;
+  Duration maxEnvelopeAge = Duration(milliseconds: 50);
+  Duration pipelineDebounceTime = Duration(milliseconds: 10);
+
+  final List<Envelope> _prePipeline = [];
+  final List<Envelope> _pipeline = [];
+  int _messageSequenceId = 0;
+  final Map<int, OutstandingSendOrRequest> _outstandingSendsAndRequests = {};
+  Timer _pipelineDebounce;
+  final Map<String, StreamController<Envelope>> _endpoints = {};
+
+  // :: WebSocket variables
+  int _nextUrlIndex = 0;
+  WebSocketChannel _websocketChannel;
+  StreamSubscription<Envelope> _socketSubscription;
+  Completer _websocketChannelDone;
+
+  final Logger _log = Logger('MatsSocket');
+
+  MatsSocket(this.appName, this.appVersion, this.wsUrls, this.socketFactory) {
+    assert(wsUrls.isNotEmpty);
+  }
+
+  // ===== Authorization handling ==================================================================
+
+  Future<Authorization> get authorization async {
+    // ?: Are we currently waiting for authorization?
+    if (_authorizationCompleter?.isCompleted == false) {
+      // Yes -> Wait for the future frpm the completer
+      _log.info(
+          'Authorization completer submitted, but not yet done, returning its future');
+      return _authorizationCompleter.future;
+    }
+    // E -> We are not waiting for an authorization
+
+    // ?: Is there no authorization present?
+    if (_authorization == null) {
+      // Yes -> First authentication, create a completer to listen for the authorization, and
+      //        return its future
+      _log.info(
+          'No authorization present, informing callback and waiting for a new authorization');
+      _authorizationCompleter = Completer<Authorization>();
+      _authorizationCallback(AuthorizationRefreshNewEvent());
+
+      // When the authorization is set, the future will resolve from the completer
+      await _authorizationCompleter.future;
+    }
+    // E -> We do have an authorization already
+
+    // Keep looping until we have an authorization that has not expired. If the callback sets an
+    // authorization that has expired, this will just loop and wait again for a non-expired
+    // authorization.
+    while (_authorization.expired) {
+      // Yes -> We need to refresh the authorization
+      _log.info('Current authorization has expired, requesting a refresh');
+      _authorizationCompleter = Completer<Authorization>();
+      _authorizationCallback(
+          AuthorizationRefreshRefreshEvent(_authorization.expire));
+
+      await _authorizationCompleter.future;
+    }
+    // --- At this point, we have a non-expired authorization
+    _log.fine('Current authorization still valid.');
+    return _authorization;
+  }
+
+  void setAuthorizationExpiredCallback(
+      AuthorizationCallback authorizationCallback) {
+    _authorizationCallback = authorizationCallback;
+  }
+
+  void setCurrentAuthorization(String authorization, DateTime expire,
+      {Duration roomForLatency = const Duration(seconds: 10)}) {
+    _authorization =
+        Authorization(authorization, expire, roomForLatency: roomForLatency);
+    _log.info(
+        'Current authorization set to ${_authorization.token}, will expire in ${expire.difference(DateTime.now())}');
+    // ?: Do we have an incomplete _authorizationCompleter?
+    if (_authorizationCompleter?.isCompleted == false) {
+      // Yes -> Set the value, so all futures listening will be notified.
+      _log.info(
+          'Authorization completer was waiting for an authorization, setting it to complete');
+      _authorizationCompleter.complete(_authorization);
+    }
+  }
+
+  // ===== WebSocketChannel handling ===============================================================
+
+  Future<WebSocketChannel> get websocketChannel async {
+    // ?: Is the current channel null, or has a close code set, indicating that it's closed?
+    if (_websocketChannel == null || _websocketChannel.closeCode != null) {
+      // Yes -> Need to create a new _websocketChannel
+
+      // ?: Do we have a current subscription?
+      if (_socketSubscription != null) {
+        // Yes -> canel it before we start a new one
+        await _socketSubscription.cancel();
+      }
+
+      // Wait for the authorization to be present before we connect to the websocket.
+      // This to avoid timeouts on the websocket connection, as we have a small window to send
+      // HELLO after establishing the connection before we get a timeout.
+      var authorization = await this.authorization;
+
+      // Connect to the next url, and increment the counter for next attempt
+      var url = wsUrls[_nextUrlIndex];
+      _log.info(
+          'WebSocket not connected, connecting to url ${_nextUrlIndex} -> ${url}');
+      _websocketChannel = await socketFactory.connect(url, 'matssocket');
+      _websocketChannelDone = Completer();
+      _nextUrlIndex = (_nextUrlIndex + 1) % wsUrls.length;
+
+      // Read the websocket stream. We expect to get json arrays of messages, so we take each
+      // payload, decode the json, and process each envelope in isolation.
+      var envelopeStream = _websocketChannel.stream.expand((payload) {
+        var envelopes = jsonDecode(payload) as List<dynamic>;
+        _log.info(
+            'Received ${envelopes.length} envelope(s) from payload $payload');
+        return envelopes.map((envelope) => Envelope.fromEncoded(envelope));
+      });
+
+      _socketSubscription = envelopeStream.listen(_onMessage,
+          onError: _onWebSocketError, onDone: _onWebSocketDone);
+
+      // Put the hello envelope into the pre-pipeline
+      _log.fine(
+          'Adding hello to pre-pipeline, authorization: ${authorization.token}');
+      _prePipeline.add(
+          Envelope.hello(appName, appVersion, sessionId, authorization.token));
+      _pipelineSend(_websocketChannel, false);
+      return _websocketChannel;
+    } else {
+      // current channel is valid
+      return _websocketChannel;
+    }
+  }
+
+  void _onMessage(Envelope envelope) {
+    _log.fine('Handling envelope: ${jsonEncode(envelope)}');
+    if (envelope.type == EnvelopeType.WELCOME) {
+      _log.info(
+          'Received welcome from [${envelope.replyMessageToClientNodename}] '
+          'after [${envelope.clientMessageCreated.difference(DateTime.now())}], '
+          'with sessionId: [${envelope.sessionId}]');
+      sessionId = envelope.sessionId;
+      return;
+    }
+    var outstandingSendsAndRequest =
+        _outstandingSendsAndRequests[envelope.messageSequenceId];
+    var handled = false;
+
+    // ?: Did we have an outstanding receive waiting for the messageSequenceId
+    if (outstandingSendsAndRequest?.receive != null &&
+        envelope.type == EnvelopeType.RECEIVED) {
+      // Yes -> resolve the receive envelope
+      _log.info(
+          'Message received for sequenceId: [${envelope.messageSequenceId}]');
+      outstandingSendsAndRequest._receive.complete(envelope);
+      handled = true;
+    }
+
+    // ?: Did we have an outstanding reply waiting for the messageSequenceId
+    if (outstandingSendsAndRequest?.reply != null &&
+        envelope.type == EnvelopeType.REPLY) {
+      // Yes -> resolve the reply envelope
+      _log.info(
+          'Message reply for sequenceId: [${envelope.messageSequenceId}], '
+          'receive accepted: [${outstandingSendsAndRequest._receive.isCompleted}]');
+      outstandingSendsAndRequest._reply.complete(envelope);
+      handled = true;
+    }
+
+    // ?: Are we done handling this outstanding request?
+    if (outstandingSendsAndRequest?.done == true) {
+      // Yes -> delete it so we don't do double delivery
+      _outstandingSendsAndRequests.remove(envelope.messageSequenceId);
+      _log.fine(
+          'Completed handling for outstanding message sequence: [${envelope.messageSequenceId}]');
+    }
+
+    // Is this a reply, that is directed to one of our own endpointIds?
+    if (envelope.type == EnvelopeType.REPLY &&
+        _endpoints.containsKey(envelope.endpointId)) {
+      // Yes -> add the message to the endpoint stream.
+      _log.info('Recived message for ${envelope.endpointId}');
+      _endpoints[envelope.endpointId].add(envelope);
+      handled = true;
+    }
+    // :: Assert that the envelope was handled
+    if (!handled) {
+      _log.severe('Could not find a handler for message ${envelope.type}');
+    }
+  }
+
+  void _onWebSocketError(dynamic error, StackTrace stackTrace) async {
+    _log.severe('Error in stream, disconnecting: $error, $stackTrace', error,
+        stackTrace);
+    await _websocketChannel.sink.close();
+    _onWebSocketDone();
+  }
+
+  void _onWebSocketDone() async {
+    _log.info(
+        'WebSocket stream is done, closeCode: ${_websocketChannel.closeCode}, '
+        'closeReason: ${_websocketChannel.closeReason}');
+    await _socketSubscription.cancel();
+    // Complete the done future, for anyone waiting.
+    _websocketChannelDone.complete('WebsocketDone');
+  }
+
+  // ===== Pipeline handling =======================================================================
+
+  Future<Envelope> _addToPipeline(Envelope envelope,
+      {Function(Envelope) receiveCallback, bool immediate}) async {
+    envelope.messageSequenceId = _messageSequenceId++;
+
+    // ?: Is the session being closed?
+    if (envelope.type == EnvelopeType.CLOSE_SESSION) {
+      // Yes -> Send now, we don't expect a reply from the server
+      _prePipeline.add(envelope);
+      _pipeline.clear();
+      sessionId = null;
+      await _pipelineScheduleSend(immediate: true, closeAfterSend: true);
+      return Envelope.empty();
+    }
+
+    // If it is a REQUEST /without/ a specific Reply (client) Endpoint defined, then it is a ...
+    var requestWithPromiseCompletion = (envelope.type == EnvelopeType.REQUEST &&
+        envelope.replyEndpointId == null);
+    OutstandingSendOrRequest outstandingSendOrRequest;
+
+    // ?: Is it an ordinary REQUEST with Promise-completion?
+    if (requestWithPromiseCompletion) {
+      // -> Yes, ordinary REQUEST with Promise-completion
+      outstandingSendOrRequest = OutstandingSendOrRequest.request(envelope);
+    } else {
+      // -> No, it is SEND or REQUEST-with-ReplyTo.
+      outstandingSendOrRequest = OutstandingSendOrRequest.send(envelope);
+    }
+
+    _pipeline.add(envelope);
+    _outstandingSendsAndRequests[envelope.messageSequenceId] =
+        outstandingSendOrRequest;
+    await _pipelineScheduleSend(immediate: immediate);
+
+    // ?: Are we waiting for a reply?
+    if (outstandingSendOrRequest.reply != null) {
+      // Yes -> We need to return the reply future from the outstandingSendOrRequest
+
+      // ?: Do we have a callback for the receive message?
+      if (receiveCallback != null) {
+        // Yes -> handle the callback first, logging if it fails
+        try {
+          receiveCallback(await outstandingSendOrRequest.receive);
+        } on Error catch (e) {
+          _log.severe('Error on invoking receive callback [${receiveCallback}]',
+              e, e.stackTrace);
+        }
+      }
+      return outstandingSendOrRequest.reply;
+    } else {
+      return outstandingSendOrRequest.receive;
+    }
+  }
+
+  Future<void> _pipelineScheduleSend(
+      {bool immediate, bool closeAfterSend}) async {
+    // ?: Are both pipelines empty?
+    if (_prePipeline.isEmpty && _pipeline.isEmpty) {
+      // Yes -> Do nothing, nothing to send
+      _log.fine('Pipeline is empty, not scheduling send');
+      return;
+    }
+
+    // ?: Is there a timer waiting to send messages
+    if (_pipelineDebounce?.isActive == true) {
+      // Yes -> cancel, we will reschedule if needed
+      _log.fine('Cancelling current timer to send pipeline messages.');
+      _pipelineDebounce.cancel();
+    }
+
+    // ?: Are we requested to send immediately?
+    if (immediate == true) {
+      // Yes -> send immediately
+      _log.fine('Immediate send requested, sending now');
+      await _pipelineSend(await websocketChannel, closeAfterSend == true);
+      return;
+    }
+
+    // ?: Is there messages in the pre pipeline?
+    if (_prePipeline.isNotEmpty) {
+      // Yes -> send immediately
+      _log.fine('Pre-pipeline has ${_prePipeline.length}, sending now');
+      await _pipelineSend(await websocketChannel, closeAfterSend == true);
+      return;
+    }
+
+    // ?: Is the pipeline full?
+    if (_pipeline.length >= pipelineMaxSize) {
+      // Yes -> send immediately
+      _log.fine('Pipeline has ${_pipeline.length} messages, sending now');
+      await _pipelineSend(await websocketChannel, closeAfterSend == true);
+      return;
+    }
+
+    // ?: Is the first message in the pipeline getting old?
+    var oldestEnvelopeEpochMsTime = _pipeline
+        .map((envelope) => envelope.clientMessageCreated.millisecondsSinceEpoch)
+        .reduce(min);
+
+    var oldestEnvelopeAge = Duration(
+        milliseconds:
+            DateTime.now().millisecondsSinceEpoch - oldestEnvelopeEpochMsTime);
+    if (oldestEnvelopeAge > maxEnvelopeAge) {
+      // Yes -> We should not wait any longer to send
+      _log.fine(
+          'Oldest envelope has been in pipeline for [${oldestEnvelopeAge}], sending now');
+      await _pipelineSend(await websocketChannel, closeAfterSend == true);
+      return;
+    }
+
+    _log.fine('Scheduling pipeline send in [${pipelineDebounceTime}]');
+    _pipelineDebounce = Timer(pipelineDebounceTime, () async {
+      await _pipelineSend(await websocketChannel, closeAfterSend == true);
+    });
+  }
+
+  void _pipelineSend(WebSocketChannel channel, bool closeAfterSend) async {
+    if (_prePipeline.isNotEmpty) {
+      var message = json.encode(_prePipeline);
+      _log.info(
+          'Flushing [${_prePipeline.length}] messages from pre-pipeline: ${message}');
+      _prePipeline.clear();
+      channel.sink.add(message);
+    }
+    if (_pipeline.isNotEmpty) {
+      var message = json.encode(_pipeline);
+      _log.info(
+          'Flushing [${_pipeline.length}] messages from pipeline: ${message}');
+      _pipeline.clear();
+      channel.sink.add(message);
+    }
+    if (closeAfterSend) {
+      _log.info('Requested to close after send, closing websocket channel');
+      var close = await Future.any([
+        channel.sink.close(1, 'Close requested'),
+        _websocketChannelDone.future
+      ]);
+      _log.info('Closed websocket channel ${close}');
+    }
+  }
+
+  // ===== API methods  ============================================================================
+
+  Future<Envelope> send(String endpointId, String traceId, dynamic message) {
+    return _addToPipeline(Envelope.send(endpointId, traceId, message));
+  }
+
+  Future<Envelope> request(String endpointId, String traceId, dynamic message,
+      [Function(Envelope) receiveCallback]) {
+    return _addToPipeline(Envelope.request(endpointId, traceId, message),
+        receiveCallback: receiveCallback);
+  }
+
+  Future<Envelope> requestReplyTo(String endpointId, String traceId,
+      dynamic message, String replyToEndpointId,
+      [String correlationId]) {
+    return _addToPipeline(Envelope.request(
+        endpointId, traceId, message, replyToEndpointId, correlationId));
+  }
+
+  Stream<Envelope> endpoint(String endpointId) {
+    // :: Assert for double-registrations
+    if (_endpoints[endpointId] != null) {
+      throw DuplicateEndpointRegistration(
+          'Cannot register more than one endpoint to same '
+          'endpointId [$endpointId], current: [${_endpoints[endpointId]}');
+    }
+    _endpoints[endpointId] = StreamController<Envelope>();
+    return _endpoints[endpointId].stream;
+  }
+
+  Future closeSession(String reason) async {
+    await _addToPipeline(Envelope.closeSession(reason));
+    return _websocketChannelDone.future;
+  }
+}
+
+// ======== API contracts ==========================================================================
+
+/// A SocketFactory is used to create new WebSocketChannel for the MatsSocket.
+///
+/// It should return a new instance of a WebSocketChannel for the current platform.
+abstract class WebSocketChannelFactory {
+  /// Connect to a WebSocketChannel
+  Future<WebSocketChannel> connect(String url, String protocol);
+}
+
+// ======== Exceptions =============================================================================
+
+/// Exception for when there is a duplicate registration of the same EndpointId.
+class DuplicateEndpointRegistration implements Exception {
+  final String message;
+
+  const DuplicateEndpointRegistration(this.message);
+
+  @override
+  String toString() => '$runtimeType: $message';
+}
+
+// ======== Authorization internal classes =========================================================
+
+abstract class AuthorizationRefreshEvent {}
+
+class AuthorizationRefreshNewEvent extends AuthorizationRefreshEvent {}
+
+class AuthorizationRefreshRefreshEvent extends AuthorizationRefreshEvent {
+  DateTime expireTime;
+
+  AuthorizationRefreshRefreshEvent(this.expireTime);
+}
+
+class Authorization {
+  String token;
+  DateTime expire;
+  Duration roomForLatency;
+
+  Authorization(this.token, this.expire,
+      {this.roomForLatency = const Duration(seconds: 10)});
+
+  bool get expired {
+    return DateTime.now().add(roomForLatency).isAfter(expire);
+  }
+}
+
+// ======== Envelope DTO ===========================================================================
+
+enum EnvelopeType {
+  HELLO,
+  WELCOME,
+  SEND,
+  REQUEST,
+  RECEIVED,
+  REPLY,
+  CLOSE_SESSION
+}
+
+extension EnvelopeTypeExtension on EnvelopeType {
+  String get name {
+    var EnvelopeTypeNameLength = runtimeType.toString().length;
+    return toString().substring(EnvelopeTypeNameLength + 1);
+  }
+}
+
+class Envelope {
+  EnvelopeType type;
+  String subType;
+  dynamic data;
+
+  String appName;
+  String appVersion;
+
+  String traceId;
+  String correlationId;
+  String endpointId;
+  String replyEndpointId;
+  String sessionId;
+  String authorization;
+  int messageSequenceId;
+  DateTime clientMessageCreated = DateTime.now();
+  DateTime clientMessageReceived;
+  String clientMessageReceivedNodename;
+  DateTime matsMessageSent;
+  DateTime matsMessageReplyReceived;
+  String matsMessageReplyReceivedNodename;
+  DateTime replyMessageToClient;
+  String replyMessageToClientNodename;
+
+  DateTime messageReceivedOnClient;
+
+  Envelope(
+      {this.type,
+      this.subType,
+      this.data,
+      this.appName,
+      this.appVersion,
+      this.traceId,
+      this.correlationId,
+      this.endpointId,
+      this.replyEndpointId,
+      this.sessionId,
+      this.authorization,
+      this.messageSequenceId,
+      this.clientMessageCreated,
+      this.clientMessageReceived,
+      this.clientMessageReceivedNodename,
+      this.matsMessageSent,
+      this.matsMessageReplyReceived,
+      this.matsMessageReplyReceivedNodename,
+      this.replyMessageToClientNodename,
+      this.replyMessageToClient,
+      this.messageReceivedOnClient});
+
+  Envelope.empty();
+
+  Envelope.fromEncoded(Map<String, dynamic> envelope) {
+    type = EnvelopeType.values.firstWhere((t) => t.name == envelope['t']);
+    data = envelope['msg'];
+    subType = envelope['st'];
+    appName = envelope['an'];
+    appVersion = envelope['av'];
+    traceId = envelope['tid'];
+    correlationId = envelope['cid'];
+    endpointId = envelope['eid'];
+    replyEndpointId = envelope['eeid'];
+    sessionId = envelope['sid'];
+    authorization = envelope['auth'];
+    messageSequenceId =
+        (envelope['cmseq'] is String) ? int.parse(envelope['cmseq']) : envelope['cmseq'];
+
+    // Timestamps and handling nodenames (pretty much debug information).
+    clientMessageCreated = readDateTime(envelope['cmcts']) ?? DateTime.now();
+    clientMessageReceived = readDateTime(envelope['cmrts']);
+    clientMessageReceivedNodename = envelope['cmrnn'];
+    messageReceivedOnClient = DateTime.now();
+    matsMessageSent = readDateTime(envelope['mmsts']);
+    matsMessageReplyReceived = readDateTime(envelope['mmrrts']);
+    matsMessageReplyReceivedNodename = envelope['mmrrnn'];
+    replyMessageToClient = readDateTime(envelope['mscts']);
+    replyMessageToClientNodename = envelope['mscnn'];
+  }
+
+  Envelope.hello(
+      this.appName, this.appVersion, this.sessionId, this.authorization) {
+    type = EnvelopeType.HELLO;
+    subType = (sessionId == null) ? 'NEW' : 'EXPECT_EXISTING';
+  }
+
+  Envelope.send(this.endpointId, this.traceId, this.data) {
+    type = EnvelopeType.SEND;
+  }
+
+  Envelope.request(this.endpointId, this.traceId, this.data,
+      [this.replyEndpointId, this.correlationId]) {
+    type = EnvelopeType.REQUEST;
+  }
+
+  Envelope.closeSession(String reason) {
+    type = EnvelopeType.CLOSE_SESSION;
+    traceId = 'MatsSocket_shutdown[$reason]${randomId(6)}';
+  }
+
+  /// Convert this Envelope to a Json Map representation, this is used by dart:convert
+  /// to encode this object for JSON.
+  Map<String, dynamic> toJson() {
+    var json = {
+      't': type.name,
+      'st': subType,
+      'tid': traceId,
+      'clv': VERSION,
+      'ts': DateTime.now().millisecondsSinceEpoch,
+      'msg': data,
+      'eid': endpointId,
+      'reid': replyEndpointId,
+      'cmseq': messageSequenceId,
+      'cid': correlationId,
+      'an': appName,
+      'av': appVersion,
+      'auth': authorization,
+      'sid': sessionId,
+      'cmcts': clientMessageCreated?.millisecondsSinceEpoch,
+      'cmrts': clientMessageReceived?.millisecondsSinceEpoch,
+      'cmrnn': clientMessageReceivedNodename,
+      'mmsts': matsMessageSent?.millisecondsSinceEpoch,
+      'mmrrts': matsMessageReplyReceived?.millisecondsSinceEpoch,
+      'mmrrnn': matsMessageReplyReceivedNodename,
+      'mscts': replyMessageToClient?.millisecondsSinceEpoch,
+      'mscnn': replyMessageToClientNodename
+    };
+
+    // Need to remove all keys where we have a null value, otherwise those fields will be
+    // included in the serialized json
+    var nullKeys = [];
+    json.forEach((key, value) {
+      if (value == null) {
+        nullKeys.add(key);
+      }
+    });
+    nullKeys.forEach(json.remove);
+
+    return json;
+  }
+
+  DateTime readDateTime(dynamic millisecondsSinceEpoch) {
+    if (millisecondsSinceEpoch == null) {
+      return null;
+    } else {
+      return DateTime.fromMillisecondsSinceEpoch(millisecondsSinceEpoch as int);
+    }
+  }
+}
+
+// ======== Internal state =========================================================================
+
+class OutstandingSendOrRequest {
+  Envelope envelope;
+  final Completer<Envelope> _receive = Completer();
+  Completer<Envelope> _reply;
+
+  OutstandingSendOrRequest.send(this.envelope);
+
+  OutstandingSendOrRequest.request(this.envelope) {
+    _reply = Completer();
+  }
+
+  // If reply is null (because this is not a request), then isComplete will be
+  // null, which is not equal to false. So we resolve to only checking receive
+  // if reply is null.
+  bool get done => _receive.isCompleted && _reply?.isCompleted != false;
+
+  Future<Envelope> get receive => _receive.future;
+
+  Future<Envelope> get reply => _reply?.future;
+}

--- a/mats-websockets/client/dart/pubspec.yaml
+++ b/mats-websockets/client/dart/pubspec.yaml
@@ -1,0 +1,14 @@
+name: mats_socket
+description: Client library for MatsSocket server.
+
+environment:
+  sdk: '>=2.7.0 <3.0.0'
+
+dependencies:
+  web_socket_channel: 1.1.0
+
+dev_dependencies:
+  pedantic: ^1.8.0
+  test: ^1.6.0
+  mockito: 4.1.1
+  logging: 0.11.3+2

--- a/mats-websockets/client/dart/test/integration.dart
+++ b/mats-websockets/client/dart/test/integration.dart
@@ -1,0 +1,142 @@
+import 'package:mats_socket/mats_socket.dart';
+import 'package:test/test.dart';
+import 'package:test_api/src/backend/invoker.dart';
+import 'package:web_socket_channel/web_socket_channel.dart';
+import 'package:web_socket_channel/io.dart';
+import 'package:logging/logging.dart';
+import 'dart:math';
+import 'dart:io';
+import 'logging.dart';
+
+class IOSocketFactory extends WebSocketChannelFactory {
+  Future<WebSocketChannel> connect(String url, String protocol) async {
+    return IOWebSocketChannel.connect(url, protocols: [protocol], headers: {}, pingInterval: Duration(seconds: 10));
+  }
+}
+
+void setAuth(MatsSocket matsSocket, {Duration duration = const Duration(minutes: 1), Duration roomForLatencyMillis = const Duration(seconds: 10)}) {
+  var now = DateTime.now();
+  var expiry = now.add(duration);
+  matsSocket.setCurrentAuthorization('DummyAuth:${expiry.millisecondsSinceEpoch}', expiry, roomForLatency: roomForLatencyMillis);
+}
+
+final log = Logger('Test');
+
+void main() {
+
+  configureLogging();
+
+  final log = Logger('Test');
+  DateTime testStart;
+  var urls = Platform.environment['MATS_SOCKET_URLS']?.split(",") ?? ['ws://localhost:8080/matssocket/json', 'ws://localhost:8081/matssocket/json'];
+  var matsSocket = MatsSocket('Test', '1.0', urls, IOSocketFactory());
+  setUp(() {
+    testStart = DateTime.now();
+    log.info('=== Test [${Invoker.current.liveTest.test.name}] starting');
+  });
+  tearDown(() async {
+    await matsSocket.closeSession('testDone');
+    log.info('=== Test [${Invoker.current.liveTest.test.name}] done after [${DateTime.now().difference(testStart)}]');
+  });
+
+  group('Authorization', () {
+
+    test('Should invoke authorization callback before making calls', () async {
+      var authCallbackCalled = false;
+      matsSocket.setAuthorizationExpiredCallback((event) {
+        authCallbackCalled = true;
+        setAuth(matsSocket);
+      });
+
+      await matsSocket.send('Test.single', 'SEND_' + randomId(6),{});
+      expect(authCallbackCalled, true);
+    });
+
+    test('Should not invoke authorization callback if authorization present', () async {
+      var authCallbackCalled = false;
+      setAuth(matsSocket);
+      matsSocket.setAuthorizationExpiredCallback((event) {
+        authCallbackCalled = true;
+      });
+
+      await matsSocket.send('Test.single', 'SEND_' + randomId(6),{});
+      expect(authCallbackCalled, false);
+    });
+
+    test('Should invoke authorization callback when expired', () async {
+
+      var authCallbackCalled = false;
+
+      setAuth(matsSocket, duration: Duration(minutes: -10));
+      matsSocket.setAuthorizationExpiredCallback((event) {
+        authCallbackCalled = true;
+        setAuth(matsSocket);
+      });
+
+      await matsSocket.send('Test.single', 'SEND_' + randomId(6),{});
+      expect(authCallbackCalled, true);
+    });
+
+    test('Should invoke authorization callback when room for latency expired', () async {
+      var authCallbackCalled = false;
+
+      setAuth(matsSocket, roomForLatencyMillis: Duration(minutes: 10));
+      matsSocket.setAuthorizationExpiredCallback((event) {
+        authCallbackCalled = true;
+        setAuth(matsSocket);
+      });
+
+      await matsSocket.send('Test.single', 'SEND_' + randomId(6),{});
+      expect(authCallbackCalled, true);
+    });
+  });
+
+  group('send', () {
+    test('Should fire and forget', () {
+      var matsSocket = authenticatedMatsSocket();
+      matsSocket.send('Test.single', 'SEND_${randomId(6)}', {});
+    });
+    
+    test('Should have a promise that resolves when received', () async {
+      var matsSocket = authenticatedMatsSocket();
+      var received = await matsSocket.send('Test.single', 'SEND_${randomId(6)}', {});
+    });
+  });
+
+  group('request', () {
+    test('Should receive a reply', () async {
+      var matsSocket = authenticatedMatsSocket();
+      var reply = await matsSocket.request('Test.single', 'REQUEST-with-Promise_${randomId(6)}', {'string': 'Request String', 'number': e});
+      expect(reply.traceId, isNotNull);
+    });
+
+    test('Should invoke the ack callback', () async {
+      var matsSocket = authenticatedMatsSocket();
+      var receiveCallbackCalled = false;
+      await matsSocket.request('Test.single', 'REQUEST-with-Promise_${randomId(6)}', {'string': 'Request String', 'number': e}, (received) {
+        receiveCallbackCalled = true;
+      });
+      expect(receiveCallbackCalled, equals(true));
+    });
+  });
+
+  group('requestReplyTo', () {
+    test('Should receive a reply on our own endpoint', () async {
+      var matsSocket = authenticatedMatsSocket();
+
+      var endpoint = matsSocket.endpoint('ClientSide.testEndpoint');
+
+      matsSocket.requestReplyTo('Test.single', 'REQUEST-with-Promise_${randomId(6)}', {'string': 'Request String', 'number': e}, 'ClientSide.testEndpoint');
+      var reply = await endpoint.first;
+      expect(reply.traceId, isNotNull);
+    });
+
+  });
+}
+
+MatsSocket authenticatedMatsSocket() {
+  var matsSocket = MatsSocket('Test', '1.0', ['ws://localhost:8080/matssocket/json', 'ws://localhost:8081/matssocket/json'], IOSocketFactory());
+
+  setAuth(matsSocket);
+  return matsSocket;
+}

--- a/mats-websockets/client/dart/test/logging.dart
+++ b/mats-websockets/client/dart/test/logging.dart
@@ -1,0 +1,28 @@
+import 'package:logging/logging.dart';
+import 'dart:io';
+
+/// Helper class to configure dart logging to print to stdout.
+void configureLogging() {
+  // We can set the log level through the environment variables, which enables
+  // setting the level from gradle.
+  switch (Platform.environment['LOG_LEVEL'] ?? 'DEBUG') {
+    case 'DEBUG': { Logger.root.level = Level.ALL; }
+    break;
+    case 'INFO': { Logger.root.level = Level.INFO; }
+    break;
+    default: { Logger.root.level = Level.SEVERE; }
+    break;
+  }
+
+  print('Setting log level to ${Platform.environment['LOG_LEVEL'] ?? 'DEBUG'}');
+
+  Logger.root.onRecord.listen((LogRecord rec) {
+    print('${rec.time} ${rec.level.name} ${rec.loggerName.padRight(12)} | ${rec.message}');
+    if (rec.error != null) {
+      print('\tError: ${rec.error}');
+    }
+    if (rec.stackTrace != null) {
+      print(rec.stackTrace);
+    }
+  });
+}

--- a/mats-websockets/client/dart/test/mock_socket_channel.dart
+++ b/mats-websockets/client/dart/test/mock_socket_channel.dart
@@ -1,0 +1,112 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:mats_socket/mats_socket.dart';
+import 'package:web_socket_channel/web_socket_channel.dart';
+import 'package:mockito/mockito.dart';
+
+typedef MessageHandler = Function(Envelope, Function(Iterable<Envelope>));
+
+class MockWebSocketSink implements WebSocketSink {
+
+  final streamController = StreamController();
+  int closeCode;
+  String closeReason;
+
+  @override
+  Future get done => streamController.done;
+
+  @override
+  Future addStream(Stream stream) => stream.forEach(add);
+
+  @override
+  void add(var data) => streamController.add(data);
+
+  @override
+  Future close([int closeCode, String closeReason]) {
+    this.closeCode = closeCode;
+    this.closeReason = closeReason;
+    return streamController.close();
+  }
+
+  @override
+  void addError(error, [StackTrace stackTrace]) =>
+      streamController.addError(error, stackTrace);
+}
+
+class MockWebSocketChannel extends Mock implements WebSocketChannel {
+
+  String url;
+  String _protocol;
+  String _closeReason;
+  int _closeCode;
+  MockWebSocketSink mockWebSocketSink = MockWebSocketSink();
+
+  final streamController = StreamController();
+
+  @override
+  Stream get stream => streamController.stream;
+
+  @override
+  WebSocketSink get sink => mockWebSocketSink;
+
+  @override
+  String get protocol => _protocol;
+
+  @override
+  int get closeCode => _closeCode;
+
+  @override
+  String get closeReason => _closeReason;
+
+  MockWebSocketChannel(this.url, this._protocol);
+
+}
+
+class MockSocketFactory extends WebSocketChannelFactory {
+
+  final MessageHandler _messageHandler;
+
+  MockSocketFactory(this._messageHandler);
+
+  MockSocketFactory.noop() : this((envelope, sink) {
+    switch (envelope.type) {
+      case EnvelopeType.HELLO : {
+        sink([Envelope(
+          type: EnvelopeType.WELCOME,
+          subType: 'NEW',
+          sessionId: '123'
+        )]);
+      }
+      break;
+      case EnvelopeType.SEND: {
+        sink([Envelope(
+          type: EnvelopeType.RECEIVED,
+          messageSequenceId: envelope.messageSequenceId
+        )]);
+      }
+      break;
+      case EnvelopeType.REQUEST: {}
+      break;
+      case EnvelopeType.CLOSE_SESSION: {}
+      break;
+      default: {}
+        break;
+    }
+  });
+
+  Future<WebSocketChannel> connect(String url, String protocol) async {
+    print('Connecting');
+    var channel = MockWebSocketChannel(url, protocol);
+    channel.mockWebSocketSink.streamController.stream.expand((payload) {
+      var envelopes = jsonDecode(payload) as List<dynamic>;
+      return envelopes.map((envelope) => Envelope.fromEncoded(envelope));
+    }).listen((envelope) {
+      _messageHandler(envelope, (replies) {
+        channel.streamController.add(jsonEncode(replies));
+      });
+    });
+    return channel;
+  }
+}
+

--- a/mats-websockets/client/dart/test/unit.dart
+++ b/mats-websockets/client/dart/test/unit.dart
@@ -1,0 +1,87 @@
+import 'package:mats_socket/mats_socket.dart';
+import 'package:test/test.dart';
+
+import 'logging.dart';
+import 'mock_socket_channel.dart';
+
+
+void main() {
+  MockSocketFactory socketFactory;
+
+  configureLogging();
+
+  setUp(() {
+    socketFactory = MockSocketFactory.noop();
+  });
+
+  group('MatsSocket constructor', () {
+
+    test('Should fail on empty url list', () {
+      expect(() => MatsSocket('', '', [], socketFactory), throwsA(TypeMatcher<AssertionError>()));
+    });
+
+    test('Should accept a single wsUrl', () {
+      MatsSocket('', '', ['ws://test/'], socketFactory);
+    });
+  });
+
+  group('Authorization', () {
+    test('Should invoke authorization callback before making calls', () async {
+      var matsSocket = MatsSocket('Test', '1.0', ['ws://localhost:8080/'], socketFactory);
+      var authCallbackCalled = false;      
+      matsSocket.setAuthorizationExpiredCallback((event) {
+        authCallbackCalled = true;
+        matsSocket.setCurrentAuthorization('Test', DateTime.now().add(Duration(minutes: 1)));
+      });
+
+      await matsSocket.send('Test.authCallback', 'SEND_${randomId(6)}', '');
+
+      expect(authCallbackCalled, true);
+    });
+
+    test('Should not invoke authorization callback if authorization present', () async {
+      var matsSocket = MatsSocket('Test', '1.0', ['ws://localhost:8080/'], socketFactory);
+      var authCallbackCalled = false;      
+      matsSocket.setCurrentAuthorization('Test', DateTime.now().add(Duration(minutes: 1)));
+      matsSocket.setAuthorizationExpiredCallback((event) {
+        authCallbackCalled = true;  
+      });
+
+      await matsSocket.send('Test.authCallback', 'SEND_${randomId(6)}', '');
+
+      expect(authCallbackCalled, false);
+    });
+
+    test('Should invoke authorization callback when expired', () async {
+      var matsSocket = MatsSocket('Test', '1.0', ['ws://localhost:8080/'], socketFactory);
+
+      var authCallbackCalled = false;
+
+      matsSocket.setCurrentAuthorization('Test', DateTime.now().subtract(Duration(minutes: 1)));
+      matsSocket.setAuthorizationExpiredCallback((event) {
+        authCallbackCalled = true;
+        matsSocket.setCurrentAuthorization('Test', DateTime.now().add(Duration(minutes: 1)));
+      });
+
+      await matsSocket.send('Test.authCallback', 'SEND_${randomId(6)}', '');
+
+      expect(authCallbackCalled, true);
+    });
+
+    test('Should invoke authorization callback when room for latency expired', () async {
+      var matsSocket = MatsSocket('Test', '1.0', ['ws://localhost:8080/'], socketFactory);
+
+      var authCallbackCalled = false;
+
+      matsSocket.setCurrentAuthorization('Test', DateTime.now().subtract(Duration(minutes: 1)), roomForLatency: Duration(minutes: 10));
+      matsSocket.setAuthorizationExpiredCallback((event) {
+        authCallbackCalled = true;
+        matsSocket.setCurrentAuthorization('Test', DateTime.now().add(Duration(minutes: 1)));
+      });
+
+      await matsSocket.send('Test.authCallback', 'SEND_' + randomId(6), '');
+
+      expect(authCallbackCalled, true);
+    });
+  });
+}

--- a/mats-websockets/client/javascript/lib/MatsSocket.js
+++ b/mats-websockets/client/javascript/lib/MatsSocket.js
@@ -14,7 +14,7 @@
 
     function MatsSocket(appName, appVersion, urls, socketFactory) {
 
-        let clientLibNameAndVersion = "integration.js,v0.8.9";
+        let clientLibNameAndVersion = "MatsSocket.js,v0.8.9";
 
         // :: Validate primary arguments
         if (typeof appName !== "string") {

--- a/mats-websockets/client/javascript/package.json
+++ b/mats-websockets/client/javascript/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "serve": "node pub/server.js",
     "test": "mocha test/unit.js",
-    "integrationTest": "mocha test/integration.js"
+    "testAll": "mocha test/integration.js test/unit.js"
   },
   "devDependencies": {
     "mocha": "^7.0.0",

--- a/mats-websockets/client/javascript/test/integration.js
+++ b/mats-websockets/client/javascript/test/integration.js
@@ -92,7 +92,7 @@ describe('MatsSocket', function () {
         //              promise rejections that are not handled will terminate the Node.js process with a non-zero exit
         //              code.
 
-        it('Should create a promise that resolves', function () {
+        it('Should have a promise that resolves when received', function () {
             // Return a promise, that mocha will watch and resolve
             return matsSocket.send("Test.single", "SEND_" + matsSocket.id(6), {string: "The String", number: Math.PI});
         });

--- a/mats-websockets/client/javascript/test/unit.js
+++ b/mats-websockets/client/javascript/test/unit.js
@@ -26,15 +26,18 @@ describe('MatsSocket', function () {
     describe('authorization', function () {
         const webSocket = {
             send(payload) {
-                const [, message] = JSON.parse(payload);
-                setTimeout(() => {
-                    webSocket.onmessage({
-                        data: JSON.stringify([
-                            {t: "WELCOME"},
-                            {t: "RECEIVED", cmseq: message.cmseq, st: "ACK"}
-                        ])
-                    });
-                }, 0);
+                JSON.parse(payload).forEach(({t, cmseq}, idx) => {
+                    if (t === 'HELLO') {
+                        setTimeout(() => {
+                            webSocket.onmessage({data: JSON.stringify([{t: "WELCOME"}])});
+                        }, idx);
+                    }
+                    if (cmseq !== undefined) {
+                        setTimeout(() => {
+                            webSocket.onmessage({data: JSON.stringify([{t: "RECEIVED", cmseq: cmseq, st: "ACK"}])});
+                        }, idx);
+                    }
+                });
             }
         };
         Object.defineProperty(webSocket, "onopen", {

--- a/mats-websockets/dart.gradle
+++ b/mats-websockets/dart.gradle
@@ -1,0 +1,69 @@
+repositories {
+    // Create a custom ivy repository that represents the dart sdk download, so that we
+    // can download the SDK using gradles download mechanisms and cache.
+    ivy {
+        url "https://storage.googleapis.com/dart-archive/channels/stable/release/"
+        patternLayout {
+            artifact "[revision]/sdk/[artifact]-[classifier]-release.[ext]"
+        }
+        metadataSources {
+            artifact()
+        }
+    }
+}
+configurations {
+    dartSdk
+}
+ext {
+    dartVersion = '2.7.0'
+}
+
+dependencies {
+    def os = org.gradle.internal.os.OperatingSystem.current();
+    if (os.isWindows()) {
+        dartSdk "com.google.dart:dartsdk:${dartVersion}:windows-x64@zip"
+    }
+    else if (os.isMacOsX()) {
+        dartSdk "com.google.dart:dartsdk:${dartVersion}:macos-x64@zip"
+    }
+    else if (os.isLinux()) {
+        dartSdk "com.google.dart:dartsdk:${dartVersion}:linux-x64@zip"
+    }
+}
+
+task dartTest(dependsOn: startMatsTestWebsocketServer) {
+    ext {
+        dartSdkPath = file("$buildDir/dart-sdk")
+    }
+    doLast {
+        copy {
+            from zipTree(configurations.dartSdk.asPath)
+            into buildDir
+        }
+        exec {
+            def os = org.gradle.internal.os.OperatingSystem.current();
+            executable os.getScriptName("$dartSdkPath/bin/pub")
+            workingDir "$projectDir/client/dart"
+            environment("MATS_SOCKET_URLS", startMatsTestWebsocketServer.wsUrls.join(","))
+
+            // logging.level returns null, so we need to check which log level is enabled to pass
+            // on to the tests, so that they log if needed.
+            if (logger.isEnabled(LogLevel.DEBUG)) {
+                environment("LOG_LEVEL", "DEBUG")
+            }
+            else if (logger.isEnabled(LogLevel.INFO)) {
+                environment("LOG_LEVEL", "INFO")
+            }
+            else {
+                environment("LOG_LEVEL", "SEVERE")
+            }
+            args = ['run', 'test', 'test/integration.dart', 'test/unit.dart']
+        }
+    }
+}
+
+// We need to ensure that dart tests are run before stop
+stopMatsTestWebsocketServer.mustRunAfter(dartTest)
+
+// Include the dart tests in the test suites.
+check.dependsOn(dartTest)

--- a/mats-websockets/javascript.gradle
+++ b/mats-websockets/javascript.gradle
@@ -20,77 +20,9 @@ task yarnInstall(type: YarnTask) {
     }
 }
 
-// Task to start a MatsTestWebsocketServer for integration tests. We will monitor the log until we get the expected number
-// of ws urls, that other tasks can then depend on
-task startMatsTestWebsocketServer(dependsOn: [configurations.testRuntimeClasspath, compileTestJava]) {
-    ext {
-        wsUrls = []
-    }
-
-    doLast {
-        String serverClassname = "com.stolsvik.mats.websocket.MatsTestWebsocketServer";
-        logger.info("Starting MatsTestWebsocketServer");
-        List<String> cmd = [
-                "${System.getenv("JAVA_HOME")}/bin/java",
-                "-classpath", sourceSets.test.runtimeClasspath.asPath,
-                serverClassname,
-                "3"
-        ]
-        Process server = cmd.execute()
-
-        // Keep a log file of the server output
-        File log = new File("$buildDir/logs/matsSocketServer-${LocalDateTime.now().withNano(0)}.log")
-        log.parentFile.mkdirs();
-
-        BufferedReader reader = new BufferedReader(new InputStreamReader(server.inputStream, StandardCharsets.UTF_8));
-        log.withWriterAppend { out ->
-            String line;
-            while (wsUrls.size < 3 && (line = reader.readLine()) != null) {
-                out.writeLine(line)
-                int urlStart = line.indexOf("WS_URL: ")
-                int urlEnd = line.indexOf("json")
-                if (urlStart > -1 && urlEnd > urlStart) {
-                    String url = line.substring(urlStart + 8, urlEnd + 4)
-                    wsUrls.add(url)
-                    logger.info("Registering WS URL: $url");
-                }
-            }
-        }
-        if (wsUrls.isEmpty()) {
-            server.errorStream.eachLine { logger.error(it) }
-            logger.error("Failed to execute: [${cmd.join(" ")}]")
-            throw new GradleException("Failed to start $serverClassname, check log above for command.");
-        }
-        logger.info("$serverClassname started");
-
-        // Fork a new thread to just keep reading and logging the MatsTestWebsocketServer
-        new Thread({
-            log.withWriterAppend { out ->
-                reader.eachLine { line ->
-                    out.writeLine(line)
-                }
-            }
-        }, "MatsTestWebsocketServer-logprinter").start()
-    }
-}
-
-// Stop the MatsTestWebsocketServer, this is done by inspecting the wsUrls field on the start task,
-// and creating a url to the shutdown page based on the first websocket url. The shutdown page is
-// a servlet that will do System.exit(0) to shutdown the server.
-task stopMatsTestWebsocketServer(dependsOn: startMatsTestWebsocketServer) {
-    doLast {
-        String shutdownUrl = startMatsTestWebsocketServer.wsUrls[0]
-                .replace("ws://", "http://")
-                .replace("/matssocket/json", "/shutdown");
-        logger.info("Shutting down MatsTestWebsocketServer by invoking '$shutdownUrl")
-        String response = new URL(shutdownUrl).text;
-        logger.info("Response: '${response}'")
-    }
-}
-
 // Execute the integration tests against a test MatsTestWebsocketServer
-task mochaIntegrationTest(type: YarnTask, dependsOn: [yarnInstall, startMatsTestWebsocketServer]) {
-    args = ['integrationTest']
+task javascriptTest(type: YarnTask, dependsOn: [yarnInstall, startMatsTestWebsocketServer]) {
+    args = ['testAll']
 
     doFirst {
         execOverrides {
@@ -99,24 +31,23 @@ task mochaIntegrationTest(type: YarnTask, dependsOn: [yarnInstall, startMatsTest
         }
     }
 }
-// Make sure that the startMatsTestWebsocketServer is finalized and shut down, while also making sure that
-// we do not shut down until mochaIntegrationTest has completed first.
-startMatsTestWebsocketServer.finalizedBy(stopMatsTestWebsocketServer)
-stopMatsTestWebsocketServer.mustRunAfter(mochaIntegrationTest)
+
+// We need to ensure that javascript tests are run before stop
+stopMatsTestWebsocketServer.mustRunAfter(javascriptTest)
 
 // :: Helper methods for people too lazy to figure out node and run these from the javascript client folder.
 
 // Run the integration test continuously, retriggering on change in the javascript code. This assumes there is
 // a server listening on ws://localhost:8080/matssocket/json
-task mochaIntegrationTestWatch(type: YarnTask, dependsOn: [yarnInstall]) {
-    args = ['integrationTest', '--watch']
+task javascriptTestWatch(type: YarnTask, dependsOn: [yarnInstall]) {
+    args = ['testAll', '--watch']
 
     execOverrides {
         it.workingDir = "${projectDir}/client/javascript"
     }
 }
 
-check.dependsOn(mochaIntegrationTest)
+check.dependsOn(javascriptTest)
 
 // Start a server to host sample html files along with the MatsSocket.js library
 task serveHtml(type: YarnTask, dependsOn: [yarnInstall]) {


### PR DESCRIPTION
Created a MatsSocket client in Dart, based on the Javascript library.
The code is slightly different, as it relies more on constructs found
in Dart, most notably Stream, Completer and Future, and the async
support in Dart.

This client fullfills the same unit and integration tests that the
Javascript library has. It has a mock version of the WebSocketChannel
for use in unit tests that allows easy development of a mock server.

I contribute this material in accordance with the signed SCA.