### PR TITLE
Synchronized the Dart library with JavaScript.

### DIFF
--- a/mats-websockets/client/dart/pubspec.yaml
+++ b/mats-websockets/client/dart/pubspec.yaml
@@ -12,3 +12,4 @@ dev_dependencies:
   test: ^1.6.0
   mockito: 4.1.1
   logging: 0.11.3+2
+  http: 0.12.0+4

--- a/mats-websockets/client/dart/test/integration.dart
+++ b/mats-websockets/client/dart/test/integration.dart
@@ -37,8 +37,8 @@ void main() {
   DateTime testStart;
   var urls = Platform.environment['MATS_SOCKET_URLS']?.split(",") ??
       [
-        'ws://localhost:8080/matssocket/json',
-        'ws://localhost:8081/matssocket/json'
+        'ws://localhost:8080/matssocket',
+        'ws://localhost:8081/matssocket'
       ];
   var matsSocket = MatsSocket('Test', '1.0', urls, IOSocketFactory());
   setUp(() {
@@ -54,10 +54,10 @@ void main() {
   group('Authorization', () {
     test('Should invoke authorization callback before making calls', () async {
       var authCallbackCalled = false;
-      matsSocket.setAuthorizationExpiredCallback((event) {
+      matsSocket.authorizationCallback = (event) {
         authCallbackCalled = true;
         setAuth(matsSocket);
-      });
+      };
 
       await matsSocket.send('Test.single', 'SEND_' + randomId(6), {});
       expect(authCallbackCalled, true);
@@ -67,9 +67,9 @@ void main() {
         () async {
       var authCallbackCalled = false;
       setAuth(matsSocket);
-      matsSocket.setAuthorizationExpiredCallback((event) {
+      matsSocket.authorizationCallback = (event) {
         authCallbackCalled = true;
-      });
+      };
 
       await matsSocket.send('Test.single', 'SEND_' + randomId(6), {});
       expect(authCallbackCalled, false);
@@ -79,10 +79,10 @@ void main() {
       var authCallbackCalled = false;
 
       setAuth(matsSocket, duration: Duration(minutes: -10));
-      matsSocket.setAuthorizationExpiredCallback((event) {
+      matsSocket.authorizationCallback = (event) {
         authCallbackCalled = true;
         setAuth(matsSocket);
-      });
+      };
 
       await matsSocket.send('Test.single', 'SEND_' + randomId(6), {});
       expect(authCallbackCalled, true);
@@ -93,10 +93,10 @@ void main() {
       var authCallbackCalled = false;
 
       setAuth(matsSocket, roomForLatencyMillis: Duration(minutes: 10));
-      matsSocket.setAuthorizationExpiredCallback((event) {
+      matsSocket.authorizationCallback = (event) {
         authCallbackCalled = true;
         setAuth(matsSocket);
-      });
+      };
 
       await matsSocket.send('Test.single', 'SEND_' + randomId(6), {});
       expect(authCallbackCalled, true);
@@ -159,8 +159,8 @@ void main() {
 MatsSocket authenticatedMatsSocket() {
   var urls = Platform.environment['MATS_SOCKET_URLS']?.split(",") ??
       [
-        'ws://localhost:8080/matssocket/json',
-        'ws://localhost:8081/matssocket/json'
+        'ws://localhost:8080/matssocket',
+        'ws://localhost:8081/matssocket'
       ];
   var matsSocket = MatsSocket('Test', '1.0', urls, IOSocketFactory());
 

--- a/mats-websockets/client/dart/test/mock_socket_channel.dart
+++ b/mats-websockets/client/dart/test/mock_socket_channel.dart
@@ -74,7 +74,7 @@ class MockSocketFactory extends WebSocketChannelFactory {
       case EnvelopeType.HELLO : {
         sink([Envelope(
           type: EnvelopeType.WELCOME,
-          subType: 'NEW',
+          subType: EnvelopeSubType.NEW,
           sessionId: '123'
         )]);
       }
@@ -82,6 +82,7 @@ class MockSocketFactory extends WebSocketChannelFactory {
       case EnvelopeType.SEND: {
         sink([Envelope(
           type: EnvelopeType.RECEIVED,
+          subType: EnvelopeSubType.ACK,
           messageSequenceId: envelope.messageSequenceId
         )]);
       }

--- a/mats-websockets/client/dart/test/unit.dart
+++ b/mats-websockets/client/dart/test/unit.dart
@@ -29,10 +29,10 @@ void main() {
     test('Should invoke authorization callback before making calls', () async {
       var matsSocket = MatsSocket('Test', '1.0', ['ws://localhost:8080/'], socketFactory);
       var authCallbackCalled = false;      
-      matsSocket.setAuthorizationExpiredCallback((event) {
+      matsSocket.authorizationCallback = (event) {
         authCallbackCalled = true;
         matsSocket.setCurrentAuthorization('Test', DateTime.now().add(Duration(minutes: 1)));
-      });
+      };
 
       await matsSocket.send('Test.authCallback', 'SEND_${randomId(6)}', '');
 
@@ -43,9 +43,9 @@ void main() {
       var matsSocket = MatsSocket('Test', '1.0', ['ws://localhost:8080/'], socketFactory);
       var authCallbackCalled = false;      
       matsSocket.setCurrentAuthorization('Test', DateTime.now().add(Duration(minutes: 1)));
-      matsSocket.setAuthorizationExpiredCallback((event) {
+      matsSocket.authorizationCallback = (event) {
         authCallbackCalled = true;  
-      });
+      };
 
       await matsSocket.send('Test.authCallback', 'SEND_${randomId(6)}', '');
 
@@ -58,10 +58,10 @@ void main() {
       var authCallbackCalled = false;
 
       matsSocket.setCurrentAuthorization('Test', DateTime.now().subtract(Duration(minutes: 1)));
-      matsSocket.setAuthorizationExpiredCallback((event) {
+      matsSocket.authorizationCallback = (event) {
         authCallbackCalled = true;
         matsSocket.setCurrentAuthorization('Test', DateTime.now().add(Duration(minutes: 1)));
-      });
+      };
 
       await matsSocket.send('Test.authCallback', 'SEND_${randomId(6)}', '');
 
@@ -74,10 +74,10 @@ void main() {
       var authCallbackCalled = false;
 
       matsSocket.setCurrentAuthorization('Test', DateTime.now().subtract(Duration(minutes: 1)), roomForLatency: Duration(minutes: 10));
-      matsSocket.setAuthorizationExpiredCallback((event) {
+      matsSocket.authorizationCallback = (event) {
         authCallbackCalled = true;
         matsSocket.setCurrentAuthorization('Test', DateTime.now().add(Duration(minutes: 1)));
-      });
+      };
 
       await matsSocket.send('Test.authCallback', 'SEND_' + randomId(6), '');
 


### PR DESCRIPTION
The Dart library should now be more in sync with the JavaScript library.
When we are connecting, we do an infinite incremental back-off to
connect to the WebSocket url. There is a difference here in Dart, as we
get the connection immediatly, and we receive the error on connection in
the stream of events, rather than in the connection future. To handle
this, we don't consider us connected until we receive the welcome
message back from the server.

Added EnvelopeSubType as an enum. This caused a bit of an issue with the
extension methods on EnvelopeType, as Dart was not able to actually
distinguish the 2 enum types as separate types, so some code changes
where done for parsing and formatting enums.

The wsUrls field was also made mutable via a setter. When the wsUrls are
set, we effectivly close and reset the connection.

The close code was changed to be aligned to the JavaScript close code,
actually copying much of the code and converting to Dart.

I contribute this material in accordance with the signed SCA.