### PR TITLE
Closes #138: Add error handling for requests

### DIFF
--- a/mats-websockets/client/dart/test/unit.dart
+++ b/mats-websockets/client/dart/test/unit.dart
@@ -28,7 +28,7 @@ void main() {
   group('Authorization', () {
     test('Should invoke authorization callback before making calls', () async {
       var matsSocket = MatsSocket('Test', '1.0', ['ws://localhost:8080/'], socketFactory);
-      var authCallbackCalled = false;      
+      var authCallbackCalled = false;
       matsSocket.authorizationCallback = (event) {
         authCallbackCalled = true;
         matsSocket.setCurrentAuthorization('Test', DateTime.now().add(Duration(minutes: 1)));
@@ -41,7 +41,7 @@ void main() {
 
     test('Should not invoke authorization callback if authorization present', () async {
       var matsSocket = MatsSocket('Test', '1.0', ['ws://localhost:8080/'], socketFactory);
-      var authCallbackCalled = false;      
+      var authCallbackCalled = false;
       matsSocket.setCurrentAuthorization('Test', DateTime.now().add(Duration(minutes: 1)));
       matsSocket.authorizationCallback = (event) {
         authCallbackCalled = true;  
@@ -82,6 +82,80 @@ void main() {
       await matsSocket.send('Test.authCallback', 'SEND_' + randomId(6), '');
 
       expect(authCallbackCalled, true);
+    });
+  });
+
+  group('Send/Receive', () {
+    test('Fail reply on receive failed', () async {
+      var socketFactory = MockSocketFactory.withHello((envelope, sink) {
+        sink([
+          Envelope(
+              type: EnvelopeType.RECEIVED,
+              subType: EnvelopeSubType.AUTH_FAIL,
+              messageSequenceId: envelope.messageSequenceId)
+        ]);
+      });
+      var matsSocket = MatsSocket('Test', '1.0', ['ws://localhost:8080/'], socketFactory);
+      matsSocket.setCurrentAuthorization('', DateTime.now().add(Duration(hours: 1)));
+
+      expect(() async => matsSocket.request('Test.failed', 'send', ''),
+          throwsException);
+    });
+
+    test('Fail reply on reply failed failed', () async {
+      var socketFactory = MockSocketFactory.withHello((envelope, sink) {
+        sink([
+          Envelope(
+              type: EnvelopeType.REPLY,
+              subType: EnvelopeSubType.REJECT,
+              messageSequenceId: envelope.messageSequenceId)
+        ]);
+      });
+      var matsSocket = MatsSocket('Test', '1.0', ['ws://localhost:8080/'], socketFactory);
+      matsSocket.setCurrentAuthorization('', DateTime.now().add(Duration(hours: 1)));
+
+      expect(() async => matsSocket.request('Test.failed', 'send', ''),
+          throwsException);
+    });
+
+    test('Trigger received on Reply', () async {
+      var socketFactory = MockSocketFactory.withHello((envelope, sink) {
+        sink([
+          Envelope(
+              type: EnvelopeType.REPLY,
+              subType: EnvelopeSubType.RESOLVE,
+              messageSequenceId: envelope.messageSequenceId)
+        ]);
+      });
+      var matsSocket = MatsSocket('Test', '1.0', ['ws://localhost:8080/'], socketFactory);
+      matsSocket.setCurrentAuthorization('', DateTime.now().add(Duration(hours: 1)));
+
+      var receiveCalled = false;
+      await matsSocket.request('Test.failed', 'send', '', (r) { receiveCalled = true; });
+
+      expect(receiveCalled, equals(true));
+    });
+
+    test('Handle reply before received', () async {
+      var socketFactory = MockSocketFactory.withHello((envelope, sink) {
+        sink([
+          Envelope(
+              type: EnvelopeType.REPLY,
+              subType: EnvelopeSubType.RESOLVE,
+              messageSequenceId: envelope.messageSequenceId),
+          Envelope(
+              type: EnvelopeType.RECEIVED,
+              subType: EnvelopeSubType.ACK,
+              messageSequenceId: envelope.messageSequenceId)
+        ]);
+      });
+      var matsSocket = MatsSocket('Test', '1.0', ['ws://localhost:8080/'], socketFactory);
+      matsSocket.setCurrentAuthorization('', DateTime.now().add(Duration(hours: 1)));
+
+      var receiveCalled = false;
+      await matsSocket.request('Test.failed', 'send', '', (r) { receiveCalled = true; });
+
+      expect(receiveCalled, equals(true));
     });
   });
 }


### PR DESCRIPTION
Added check for subtype on RECEIVED and REPLY handler, that propagates
to the caller properly.

The MockSocketFactory was also extened to more easily write unit tests
that handles hello message in a default manner.

I contribute this material in accordance with the signed SCA.