### PR TITLE
Updated version to 0.11.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,8 @@ kahadb/
 # H2 test database
 matsTestH2DB.mv.db
 /mats.iml
+
+# List of repositories to publish to
+# This should not be checked in, and instead be maintained by each developer to control where he
+# wishes to publish to.
+repositories.gradle

--- a/build.gradle
+++ b/build.gradle
@@ -7,8 +7,6 @@ wrapper {
 
 // Version of Mats
 allprojects {
-    group = 'com.stolsvik.mats'
-    version = '0.10.0'  // NOTE! Also set in MatsSocket.js and MatsSocket.dart
 }
 
 // Spring, ActiveMQ and Jackson JSON versions: Used in several sub projects
@@ -61,6 +59,44 @@ subprojects {
             attributes 'Implementation-Title': 'MATS',
                     'Implementation-Version': version
         }
+    }
+
+    publishing {
+        publications {
+            mavenJava(MavenPublication) {
+                pom {
+                    name = 'MATS^3'
+                    description = 'Message-based Asynchronous Transactional Staged Stateful Services'
+                    url = 'https://github.com/stolsvik/mats'
+                    licenses {
+                        license {
+                            name = 'The Apache License, Version 2.0'
+                            url = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+                        }
+                    }
+                    developers {
+                        developer {
+                            id = 'stolsvik'
+                            name = 'Endre Stølsvik'
+                            email = 'endre@stolsvik.com'
+                        }
+                    }
+                    scm {
+                        connection = 'scm:git:https://github.com/stolsvik/mats.git'
+                        developerConnection = 'scm:git:ssh:git@github.com:stolsvik/mats.git'
+                        url = 'https://github.com/stolsvik/mats'
+                    }
+                }
+                from components.java
+            }
+        }
+    }
+
+    // ------------------------------------------------
+    // -- Release configuration. The release file is not checked in to version control, and should
+    //    instead be kept locally to configure how to deploy this.
+    if (file("${rootProject.projectDir}/repositories.gradle").exists()) {
+        apply from: "${rootProject.projectDir}/repositories.gradle"
     }
 
     // ------------------------------------------------

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,3 @@
+group=com.stolsvik.mats
+# NOTE! Also set in MatsSocket.js and MatsSocket.dart
+version=0.11.0

--- a/mats-websockets/client/dart/lib/src/MatsSocket.dart
+++ b/mats-websockets/client/dart/lib/src/MatsSocket.dart
@@ -22,7 +22,7 @@ final Logger _logger = Logger('MatsSocket');
 const String ALPHABET = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
 // JSON-non-quoted and visible Alphabet: 92 chars.
 const String JSON_ALPHABET = '!#\$%&\'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[]^_`abcdefghijklmnopqrstuvwxyz{|}~';
-const CLIENT_LIB_NAME_AND_VERSION = 'MatsSocket_old.dart,v0.10.0;';
+const CLIENT_LIB_NAME_AND_VERSION = 'MatsSocket_old.dart,v0.11.0;';
 
 
 typedef SessionClosedEventListener = Function(MatsSocketCloseEvent);

--- a/mats-websockets/client/javascript/lib/MatsSocket.js
+++ b/mats-websockets/client/javascript/lib/MatsSocket.js
@@ -1222,7 +1222,7 @@
      * @constructor
      */
     function MatsSocket(appName, appVersion, urls, config) {
-        let clientLibNameAndVersion = "MatsSocket.js,v0.10.0";
+        let clientLibNameAndVersion = "MatsSocket.js,v0.11.0";
 
         // :: Validate primary arguments
         if (typeof appName !== "string") {

--- a/mats-websockets/dart.gradle
+++ b/mats-websockets/dart.gradle
@@ -1,3 +1,7 @@
+configurations {
+    dart
+}
+
 repositories {
     // Create a custom ivy repository that represents the dart sdk download, so that we
     // can download the SDK using gradles download mechanisms and cache.
@@ -82,3 +86,18 @@ stopMatsTestWebsocketServer.mustRunAfter(dartTest)
 
 // Include the dart tests in the test suites.
 check.dependsOn(dartTest)
+
+
+task archiveDartLib(type: Zip) {
+    from "$projectDir/client/dart/lib"
+    into "mats_socket-${project.version}-dart"
+    archiveClassifier = "dart"
+}
+
+publishing {
+    publications {
+        mavenJava(MavenPublication) {
+            artifact archiveDartLib
+        }
+    }
+}

--- a/mats-websockets/javascript.gradle
+++ b/mats-websockets/javascript.gradle
@@ -1,6 +1,3 @@
-import java.nio.charset.StandardCharsets
-import java.time.LocalDateTime
-
 node {
     // Version of node to use.
     version = '12.14.0'
@@ -56,5 +53,19 @@ task serveHtml(type: YarnTask, dependsOn: [yarnInstall]) {
 
     execOverrides {
         it.workingDir = "${projectDir}/client/javascript"
+    }
+}
+
+task archiveJavaScriptLib(type: Zip) {
+    from "$projectDir/client/javascript/lib"
+    into "mats_socket-${project.version}-js"
+    archiveClassifier = "javascript"
+}
+
+publishing {
+    publications {
+        mavenJava(MavenPublication) {
+            artifact archiveJavaScriptLib
+        }
     }
 }


### PR DESCRIPTION
This also adds tasks to publish the JavaScript and Dart client as zip
files, so that all of the artifacts are published to the same repository
at the same version.

The version number was moved to gradle.properties, so that we can
override it on the command line with:

    ./gradlew publish -Pversion=0.11.0-CUSTOM

I contribute this material in accordance with the signed SCA.