### PR TITLE
Improve unit test for reauth

### DIFF
--- a/mats-websockets/client/dart/lib/src/MatsSocket.dart
+++ b/mats-websockets/client/dart/lib/src/MatsSocket.dart
@@ -750,7 +750,7 @@ class MatsSocket {
   ///         using [addInitiationProcessedEventListener()]
   Future<ReceivedEvent> send(String endpointId, String traceId, dynamic message,
       {bool suppressInitiationProcessedEvent = false}) {
-    final handler = Completer<ReceivedEvent>();
+    final handler = Completer<ReceivedEvent>.sync();
     final initiation = _Initiation(suppressInitiationProcessedEvent, debug ?? 0, handler.complete, handler.completeError);
     final envelope = MatsSocketEnvelopeDto(
         type: MessageType.SEND,
@@ -2610,7 +2610,7 @@ class _Initiation {
 
 class _Request {
   final Duration timeout;
-  final Completer<MessageEvent> _completer = Completer();
+  final Completer<MessageEvent> _completer = Completer.sync();
   final String replyToTerminatorId;
   final dynamic correlationInformation;
 

--- a/mats-websockets/client/dart/lib/src/MatsSocketPlatform.dart
+++ b/mats-websockets/client/dart/lib/src/MatsSocketPlatform.dart
@@ -29,7 +29,7 @@ abstract class MatsSocketPlatform {
 
   WebSocket connect(Uri webSocketUri, String protocol, String authorization);
 
-  Future<String> get userAgent;
+  String get userAgent;
 
   ConnectResult sendAuthorizationHeader(Uri websocketUri, String authorization);
 

--- a/mats-websockets/client/dart/lib/src/MatsSocketPlatformHtml.dart
+++ b/mats-websockets/client/dart/lib/src/MatsSocketPlatformHtml.dart
@@ -23,7 +23,7 @@ class MatsSocketPlatformHtml extends MatsSocketPlatform {
   }
 
   @override
-  Future<String> get userAgent async => html.window.navigator.userAgent;
+  String get userAgent => html.window.navigator.userAgent;
 
   @override
   ConnectResult sendAuthorizationHeader(Uri websocketUri, String authorization) {

--- a/mats-websockets/client/dart/lib/src/MatsSocketPlatformNative.dart
+++ b/mats-websockets/client/dart/lib/src/MatsSocketPlatformNative.dart
@@ -36,7 +36,7 @@ class MatsSocketPlatformNative extends MatsSocketPlatform {
   }
 
   @override
-  Future<String> get userAgent async {
+  String get userAgent {
     final osName = io.Platform.operatingSystem;
     final osVersion = io.Platform.operatingSystemVersion;
     final dartVersion = io.Platform.version;

--- a/mats-websockets/client/dart/test/integration_listeners.dart
+++ b/mats-websockets/client/dart/test/integration_listeners.dart
@@ -153,9 +153,9 @@ void main() {
       });
 
       Future runRequestTest(bool includeStash) async {
-        var initiationProcessedEvent = Completer<InitiationProcessedEvent>();
-        var receivedCompleter = Completer<ReceivedEvent>();
-        var repliedMessageEvent = Completer<MessageEvent>();
+        var initiationProcessedEvent = Completer<InitiationProcessedEvent>.sync();
+        var receivedCompleter = Completer<ReceivedEvent>.sync();
+        var repliedMessageEvent = Completer<MessageEvent>.sync();
         var traceId = 'InitiationProcessedEvent_request_${id(6)}';
         var msg = {'string': 'The Strange', 'number': math.e};
 

--- a/mats-websockets/client/dart/test/lib/MatsSocketTransportMock.dart
+++ b/mats-websockets/client/dart/test/lib/MatsSocketTransportMock.dart
@@ -77,7 +77,7 @@ class MatsSocketTransportMock extends MatsSocketPlatform {
   }
 
   @override
-  Future<String> get userAgent => Future.value('UnitTest userAgent');
+  String get userAgent => 'UnitTest userAgent';
 
 }
 


### PR DESCRIPTION
Changed the reauth test to assert the order in which things occur,
checking that we first get the ack, then the reauth, before finally
receiving the reply from the server.

Also changed all Completers internally in Mats to be sync Completers,
that way any listeners are triggered inline, rather than waiting for the
current thread to complete. This was earlier necessary at least for some
unit tests that where very strict on the ordering of events. By making
all Completers sync, all event ordering is deterministic.

Finally, changed the user agent to no longer be a future, as there was
no need for it to be, and having it as a future will complicate how we
set the clv part when authenticating.

I contribute this material in accordance with the signed SCA.