### PR TITLE
Introduced additional test for the MatsFuturizer

### DIFF
--- a/mats-util/src/test/java/com/stolsvik/mats/util/Test_MatsFuturizer_ContextPayloadsAndTraceProperties.java
+++ b/mats-util/src/test/java/com/stolsvik/mats/util/Test_MatsFuturizer_ContextPayloadsAndTraceProperties.java
@@ -1,0 +1,113 @@
+package com.stolsvik.mats.util;
+
+import java.util.Objects;
+import java.util.Random;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.stolsvik.mats.MatsEndpoint.DetachedProcessContext;
+import com.stolsvik.mats.MatsInitiator.InitiateLambda;
+import com.stolsvik.mats.lib_test.MatsBasicTest;
+import com.stolsvik.mats.util.MatsFuturizer.Reply;
+
+/**
+ * Tests both attaching of bytes (and then getting them from the Reply object), and also the {@link InitiateLambda}
+ * interface for {@link MatsFuturizer}, where it is made available via the method {@link
+ * MatsFuturizer#futurizeGeneric(String, String, String, int, TimeUnit, Class, Object, InitiateLambda)}
+ *
+ * @author Endre Stølsvik, 2020 - http://stolsvik.com/, endre@stolsvik.com
+ * @author Kevin Mc Tiernan, 2020 - kmctiernan@gmail.com
+ */
+public class Test_MatsFuturizer_ContextPayloadsAndTraceProperties extends MatsBasicTest {
+
+    private static final byte[] BYTE_ARRAY = new byte[1024];
+
+    static {
+        new Random(-3).nextBytes(BYTE_ARRAY);
+    }
+
+    private static final String SERVICE_MESSAGE_APPEND = ":appendedAtService";
+    private static final String KEY_ATTACHED_STRING = "attachedString";
+    private static final String KEY_ATTACHED_BYTES = "attachedBytes";
+    private static final String KEY_TRACE_PROPERTY = "traceProperty";
+    private static final String KEY_TRACE_PROPERTY_FROM_SERVICE = "tracePropertyFromService";
+
+    @Before
+    public void setupService() {
+        matsRule.getMatsFactory().single(SERVICE, String.class, String.class, (context, incomingMessage) -> {
+            // Pass the attached string and bytes back to the invoker.
+            context.addString(KEY_ATTACHED_STRING, context.getString(KEY_ATTACHED_STRING) + ":xyz");
+            context.addBytes(KEY_ATTACHED_BYTES, context.getBytes(KEY_ATTACHED_BYTES));
+
+            // Add a trace property
+            context.setTraceProperty(KEY_TRACE_PROPERTY_FROM_SERVICE, new TestDto("XYZ", Math.E));
+            return incomingMessage + SERVICE_MESSAGE_APPEND;
+        });
+    }
+
+    @Test
+    public void futureGet() throws InterruptedException, ExecutionException, TimeoutException {
+        String traceId = UUID.randomUUID().toString();
+        String request = UUID.randomUUID().toString();
+
+        MatsFuturizer futurizer = MatsFuturizer.createMatsFuturizer(matsRule.getMatsFactory(), "TestFuturizer");
+
+        CompletableFuture<Reply<String>> future = futurizer.futurizeGeneric(
+                traceId, "futureGet", SERVICE, 1000, TimeUnit.MILLISECONDS, String.class, request,
+                msg -> {
+                    msg.addString(KEY_ATTACHED_STRING, "attached_String");
+                    msg.addBytes(KEY_ATTACHED_BYTES, BYTE_ARRAY);
+                    msg.setTraceProperty(KEY_TRACE_PROPERTY, new TestDto("DTO", Math.PI));
+                });
+        Reply<String> reply = future.get(1, TimeUnit.SECONDS);
+
+        // Assert that we got the expected reply.
+        Assert.assertEquals(request + SERVICE_MESSAGE_APPEND, reply.getReply());
+
+        // :: Assert that the attached String and Byte Array, and 2 x Trace Properties, are present on the context.
+        DetachedProcessContext context = reply.getContext();
+        Assert.assertEquals("attached_String:xyz", context.getString(KEY_ATTACHED_STRING));
+        Assert.assertArrayEquals(BYTE_ARRAY, context.getBytes(KEY_ATTACHED_BYTES));
+        Assert.assertEquals(new TestDto("DTO", Math.PI),
+                context.getTraceProperty(KEY_TRACE_PROPERTY, TestDto.class));
+        Assert.assertEquals(new TestDto("XYZ", Math.E),
+                context.getTraceProperty(KEY_TRACE_PROPERTY_FROM_SERVICE, TestDto.class));
+    }
+
+    private static class TestDto {
+        String string;
+        double number;
+
+        public TestDto() {
+        }
+
+        TestDto(String string, double number) {
+            this.string = string;
+            this.number = number;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof TestDto)) {
+                return false;
+            }
+            return Double.compare(((TestDto) o).number, number) == 0
+                    && Objects.equals(((TestDto) o).string, string);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(string, number);
+        }
+    }
+}

--- a/mats-util/src/test/java/com/stolsvik/mats/util/Test_MatsFuturizer_FailedSerializationFuture.java
+++ b/mats-util/src/test/java/com/stolsvik/mats/util/Test_MatsFuturizer_FailedSerializationFuture.java
@@ -1,0 +1,123 @@
+package com.stolsvik.mats.util;
+
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.function.Function;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.stolsvik.mats.lib_test.MatsBasicTest;
+import com.stolsvik.mats.util.MatsFuturizer.Reply;
+
+/**
+ * Test for deserialization failure and that this throws an exception to the threads waiting for the Future.
+ *
+ * @author Hallvard Nygård, 2020, hallvard.nygard@gmail.com
+ * @author Kevin Mc Tiernan, 2020, kmctiernan@gmail.com
+ */
+public class Test_MatsFuturizer_FailedSerializationFuture extends MatsBasicTest {
+
+    @Before
+    public void setupServiceEndpoint() {
+        matsRule.getMatsFactory().single(SERVICE, DtoWeSend.class, String.class,
+                (context, incomingMsg) -> new DtoWeSend(incomingMsg));
+    }
+
+    /**
+     * Verifies that the deserialization failure is propagated to the get invoker.
+     * <p>
+     * In this test there is no {@link CompletableFuture#exceptionally(Function)} handling, a get is executed on the
+     * future and we assert that the resulting exception is the one we expect.
+     */
+    @Test(timeout = 5000)
+    public void futureGet() {
+        MatsFuturizer futurizer = MatsFuturizer.createMatsFuturizer(matsRule.getMatsFactory(), "TestFuturizer");
+        String traceId = UUID.randomUUID().toString();
+
+        CompletableFuture<Reply<DtoWeExpect>> future = futurizer.futurizeInteractiveUnreliable(traceId,
+                "futureGet",
+                SERVICE,
+                DtoWeExpect.class, "NOK");
+        try {
+            Reply<DtoWeExpect> reply = future.get();
+            Assert.fail("We should not get a response. Currency was " + reply.getReply().currency);
+        }
+        catch (Throwable e) {
+            log.info("Got the exception. Hoping it's the right one. Logging stacktrace just in case.", e);
+            Assert.assertEquals("Could not deserialize the data contained in MatsObject to class"
+                    + " [com.stolsvik.mats.util.Test_MatsFuturizer_FailedSerializationFuture$DtoWeExpect].", e.getCause().getMessage());
+        }
+    }
+
+    /**
+     * Verifies that the deserialization failure is propagated and can be handled within
+     * {@link CompletableFuture#exceptionally(Function)}.
+     */
+    @Test(timeout = 5000)
+    public void futureThenApply_andExceptionally_Common()
+            throws InterruptedException, ExecutionException {
+        MatsFuturizer futurizer = MatsFuturizer.createMatsFuturizer(matsRule.getMatsFactory(), "TestFuturizer");
+        String traceId = UUID.randomUUID().toString();
+
+        DtoWeExpect r = futurizer.futurizeInteractiveUnreliable(
+                traceId,
+                "futureGet",
+                SERVICE,
+                DtoWeExpect.class,
+                "NOK")
+                .thenApply(Reply::getReply)
+                .exceptionally(e -> {
+                    log.info("Got the exception. Hoping it's the right one. Logging stacktrace just in case.", e);
+                    Assert.assertEquals("Could not deserialize the data contained in MatsObject to class "
+                                    + "[com.stolsvik.mats.util.Test_MatsFuturizer_FailedSerializationFuture$DtoWeExpect].",
+                            e.getCause().getMessage());
+                    return new DtoWeExpect("ExceptionallyTest");
+                })
+                // Make it wait
+                .get();
+        Assert.assertEquals("ExceptionallyTest", r.currency);
+    }
+
+    /**
+     * The DTO we send from the service. Not matching what we expect on the other side.
+     */
+    public static class DtoWeSend {
+        // Serialized to:
+        // "currency":{"currencyCode":"NOK"}
+        public MyObject currency;
+
+        public DtoWeSend() {
+        }
+
+        public DtoWeSend(String incomingMessage) {
+            currency = new MyObject();
+            currency.currencyCode = incomingMessage;
+        }
+    }
+
+    public static class MyObject {
+        // CHECKSTYLE IGNORE VisibilityModifier FOR NEXT 1 LINES
+        public String currencyCode;
+
+        public MyObject() {
+        }
+    }
+
+    /**
+     * The DTO we expect to receive. Not matching what the service is sending.
+     */
+    public static class DtoWeExpect {
+        // This should throw an exception during deserialization as MyObject does not deserialize to String
+        public String currency;
+
+        public DtoWeExpect() {
+        }
+
+        public DtoWeExpect(String currency) {
+            this.currency = currency;
+        }
+    }
+}


### PR DESCRIPTION
Added the following test classes to verify behavior of the
MatsFuturizer:

Test_MatsFuturizer_ContextPayloadsAndTraceProperties
   Tests that attaching bytes, string and trace properties through an
   InitiateLambda functions as one would expect when utilizing
   the MatsFuturizer#futurizeGeneric method.

Test_MatsFuturizer_FailedSerializationFuture
   Test for deserialization failure and that this throws an
   exception to the threads waiting for the Future.

I contribute this material in accordance with Storebrand's signed SCA.