### PR TITLE
Create new lists rather than clear acks/nacks.

### DIFF
--- a/mats-websockets/client/dart/lib/src/MatsSocket.dart
+++ b/mats-websockets/client/dart/lib/src/MatsSocket.dart
@@ -2300,8 +2300,8 @@ class MatsSocket {
     }
   }
 
-  final List<String> _laterAcks = [];
-  final List<String> _laterNacks = [];
+  List<String> _laterAcks = [];
+  List<String> _laterNacks = [];
   Timer _laterAckTimeoutId;
 
   void _sendAckLater(MessageType type, String smid, [String description]) {
@@ -2337,13 +2337,13 @@ class MatsSocket {
               type: MessageType.ACK,
               ids: _laterAcks
           ));
-          _laterAcks.clear();
+          _laterAcks = [];
       } else if (_laterAcks.length == 1) {
           _addEnvelopeToPipeline_EvaluatePipelineLater(MatsSocketEnvelopeDto(
               type: MessageType.ACK,
               serverMessageId: _laterAcks[0]
           ));
-          _laterNacks.clear();
+          _laterAcks.clear();
       }
       // NACKs
       if (_laterNacks.length > 1) {
@@ -2351,7 +2351,7 @@ class MatsSocket {
               type: MessageType.NACK,
               ids: _laterNacks
           ));
-          _laterNacks.clear();
+          _laterNacks = [];
       } else if (_laterNacks.length == 1) {
           _addEnvelopeToPipeline_EvaluatePipelineLater(MatsSocketEnvelopeDto(
               type: MessageType.NACK,
@@ -2361,7 +2361,7 @@ class MatsSocket {
       }
   }
 
-  final List<String> _laterAck2s = [];
+  List<String> _laterAck2s = [];
   Timer _laterAck2TimeoutId;
 
   void _sendAck2Later(List<String> ids) {
@@ -2382,7 +2382,7 @@ class MatsSocket {
               type: MessageType.ACK2,
               ids: _laterAck2s
           ));
-          _laterAck2s.clear();
+          _laterAck2s = [];
       } else if (_laterAck2s.length == 1) {
           _addEnvelopeToPipeline_EvaluatePipelineLater(MatsSocketEnvelopeDto(
               type: MessageType.ACK2,

--- a/mats-websockets/src/main/java/com/stolsvik/mats/websocket/impl/MatsSocketSessionAndMessageHandler.java
+++ b/mats-websockets/src/main/java/com/stolsvik/mats/websocket/impl/MatsSocketSessionAndMessageHandler.java
@@ -639,7 +639,12 @@ class MatsSocketSessionAndMessageHandler implements Whole<String>, MatsSocketSta
                 // TODO: Use the MessageToWebSocketForwarder for this.
                 MatsSocketEnvelopeWithMetaDto ack2Envelope = new MatsSocketEnvelopeWithMetaDto();
                 ack2Envelope.t = ACK2;
-                if (clientAckIds.size() > 1) {
+                if (clientAckIds.isEmpty()) {
+                    // This should not happen, the client should not send an empty list.
+                    closeSessionAndWebSocketWithProtocolError("An empty list of ackids was sent");
+                    return;
+                }
+                else if (clientAckIds.size() > 1) {
                     ack2Envelope.ids = clientAckIds;
                 }
                 else {


### PR DESCRIPTION
When sending acks and nacks, we where clearing the lists, rather than
creating new ones. This will cause an error downstream, as the same
instance is used for sending. By the time we are sending the acks over
the WebSocket, the list is already cleared, and we end up sending an
empty list.

I contribute this material in accordance with the signed SCA.