### PR TITLE
Fixes #189: Handle unmapped WebSocket close codes.

### DIFF
--- a/mats-websockets/build.gradle
+++ b/mats-websockets/build.gradle
@@ -1,5 +1,8 @@
 import java.nio.charset.StandardCharsets
 import java.time.LocalDateTime
+import java.util.concurrent.DelayQueue
+import java.util.concurrent.LinkedBlockingQueue
+import java.util.concurrent.PriorityBlockingQueue
 
 // mats-websockets
 plugins {
@@ -49,7 +52,7 @@ dependencies {
 
 // Task to start a MatsTestWebsocketServer for integration tests. We will monitor the log until we get the expected number
 // of ws urls, that other tasks can then depend on
-task startMatsTestWebsocketServer(dependsOn: [configurations.testRuntimeClasspath, compileTestJava]) {
+task startMatsTestWebsocketServer(dependsOn: [configurations.testRuntimeClasspath, compileTestJava, processTestResources]) {
     ext {
         wsUrls = []
     }

--- a/mats-websockets/client/dart/lib/src/MatsSocket.dart
+++ b/mats-websockets/client/dart/lib/src/MatsSocket.dart
@@ -1827,7 +1827,7 @@ class MatsSocket {
           || (code == MatsSocketCloseCodes.CLOSE_SESSION.code)
           || (code == MatsSocketCloseCodes.SESSION_LOST.code)) {
           // -> One of the specific "Session is closed" CloseCodes -> Reject all outstanding, this MatsSocket is trashed.
-          error('session closed from server', 'The WebSocket was closed with a CloseCode [${MatsSocketCloseCodesExtension.fromCode(code)}] signifying that our MatsSocketSession is closed, reason:[${reason}].', closeEvent);
+          error('session closed from server', 'The WebSocket was closed with a CloseCode [${MatsSocketCloseCodesExtension.nameFor(code)}] signifying that our MatsSocketSession is closed, reason:[${reason}].', closeEvent);
 
           // Hold on to how many outstanding initiations there are now
           var outstandingInitiations = _outboxInitiations.length;
@@ -1842,7 +1842,7 @@ class MatsSocket {
       } else {
           // -> NOT one of the specific "Session is closed" CloseCodes -> Reconnect and Reissue all outstanding..
           if (code != MatsSocketCloseCodes.DISCONNECT.code) {
-              _logger.info('We were closed with a CloseCode [${MatsSocketCloseCodesExtension.fromCode(code)}] that does NOT denote that we should close the session. Initiate reconnect and reissue all outstanding.');
+              _logger.info('We were closed with a CloseCode [${MatsSocketCloseCodesExtension.nameFor(code)}] that does NOT denote that we should close the session. Initiate reconnect and reissue all outstanding.');
           } else {
               _logger.info('We were closed with the special DISCONNECT close code - act as we lost connection, but do NOT start to reconnect.');
           }

--- a/mats-websockets/client/dart/lib/src/MatsSocketCloseEvent.dart
+++ b/mats-websockets/client/dart/lib/src/MatsSocketCloseEvent.dart
@@ -93,7 +93,12 @@ enum MatsSocketCloseCodes {
   /// that a connection is wonky and wants to ditch it, but the server has not realized the same yet. When the
   /// server then gets the new connect, it'll see that there is an active WebSocket already. It needs to close
   /// that. But the client "must not do anything" other than what it already is doing - reconnecting.
-  DISCONNECT
+  DISCONNECT,
+
+  /// Indicates a WebSocket close code that does not map to any specific MatsSocketCloseCode.
+  /// This can occur when there WebSocket is closed by other mechanisms than vie MatsSocket, and the
+  /// close code is one that is unknown to the MatsSocket library.
+  UNKNOWN
 }
 
 extension MatsSocketCloseCodesExtension on MatsSocketCloseCodes {
@@ -117,6 +122,8 @@ extension MatsSocketCloseCodesExtension on MatsSocketCloseCodes {
         return 4002;
       case MatsSocketCloseCodes.DISCONNECT:
         return 4003;
+      case MatsSocketCloseCodes.UNKNOWN:
+        return -1;
       default:
         throw ArgumentError.value(this, 'MatsSocketCloseCodes', 'No code defined for enum value');
     }
@@ -142,11 +149,17 @@ extension MatsSocketCloseCodesExtension on MatsSocketCloseCodes {
         return 'RECONNECT';
       case MatsSocketCloseCodes.DISCONNECT:
         return 'DISCONNECT';
+      case MatsSocketCloseCodes.UNKNOWN:
+        return 'UNKNOWN';
       default:
         throw ArgumentError.value(this, 'MatsSocketCloseCodes', 'No name defined for enum value');
     }
   }
 
+  static String nameFor(final int code) {
+    var matsSocketCloseCode = fromCode(code);
+    return (matsSocketCloseCode == MatsSocketCloseCodes.UNKNOWN) ? 'UNKNOWN($code)' : matsSocketCloseCode.name;
+  }
 
   /// Convert a close code int to a ClodeCodes enum.
   static MatsSocketCloseCodes fromCode(final int code) {
@@ -175,7 +188,7 @@ extension MatsSocketCloseCodesExtension on MatsSocketCloseCodes {
       case 4003:
         return MatsSocketCloseCodes.DISCONNECT;
       default:
-        throw ArgumentError.value(code, 'code', 'Unknown MatsSocketCloseCodes code');
+        return MatsSocketCloseCodes.UNKNOWN;
     }
   }
 }
@@ -248,7 +261,12 @@ enum CloseCodes {
   /// applications expecting a status code to indicate that the
   /// connection was closed due to a failure to perform a TLS handshake
   /// (e.g., the server certificate can't be verified).
-  TLS_HANDSHAKE_FAILURE
+  TLS_HANDSHAKE_FAILURE,
+  /// To handle close codes that are not defined in the spec (it could be any integer, we can't predict everything
+  /// that occurs in the wild), we need to use this UNKNOWN enum value. When this occurs, we will also lose the
+  /// information about which specific closeCode was used. In the library we do log the closeCode directly, rather
+  /// than this resolved enum value, so this does not have any practical concerns for the library itself.
+  UNKNOWN
 }
 
 extension CloseCodesExtension on CloseCodes {
@@ -284,6 +302,11 @@ extension CloseCodesExtension on CloseCodes {
         return 1013;
       case CloseCodes.TLS_HANDSHAKE_FAILURE:
         return 1015;
+      case CloseCodes.UNKNOWN:
+        // Since we do not know which close code we are dealing with, we do not
+        // know which integer to return here either. -1 seems like a good enough compromise
+        // to represent this.
+        return -1;
       default:
         throw ArgumentError.value(this, 'CloseCodes', 'No code defined for enum value');
     }
@@ -321,6 +344,8 @@ extension CloseCodesExtension on CloseCodes {
         return 'TRY_AGAIN_LATER';
       case CloseCodes.TLS_HANDSHAKE_FAILURE:
         return 'TLS_HANDSHAKE_FAILURE';
+      case CloseCodes.UNKNOWN:
+        return 'UNKNOWN';
       default:
         throw ArgumentError.value(this, 'CloseCodes', 'No name defined for enum value');
     }
@@ -361,7 +386,7 @@ extension CloseCodesExtension on CloseCodes {
       case 1015:
         return CloseCodes.TLS_HANDSHAKE_FAILURE;
       default:
-        throw ArgumentError.value(code, 'code', 'Unknown CloseCode value');
+        return CloseCodes.UNKNOWN;
     }
   }
 }

--- a/mats-websockets/client/dart/test/integration_authentication.dart
+++ b/mats-websockets/client/dart/test/integration_authentication.dart
@@ -1,12 +1,16 @@
 import 'dart:async';
+import 'dart:math' as math;
 
+import 'package:logging/logging.dart';
 import 'package:mats_socket/mats_socket.dart';
 import 'package:test/test.dart';
+
 import 'lib/env.dart';
-import 'dart:math' as math;
 
 void main() {
   configureLogging();
+
+  final _logger = Logger('integration_authentication');
 
   group('MatsSocket integration-tests of Authentication & Authorization', () {
     MatsSocket matsSocket;
@@ -21,12 +25,11 @@ void main() {
           'DummyAuth:$userId:${expiry.millisecondsSinceEpoch}', expiry, roomForLatencyMillis);
     }
 
-    setUp(() {
-      matsSocket = MatsSocket('TestApp', '1.2.3', serverUris);
-    });
+    setUp(() => matsSocket = createMatsSocket());
 
     tearDown(() async  {
       await matsSocket.close('Test done');
+      _logger.info('=========== Closed MatsSocket [${matsSocket?.matsSocketInstanceId}] ===========');
     });
 
     group('MatsSocket integration tests of Authentication & Authorization', () {

--- a/mats-websockets/client/dart/test/integration_basic.dart
+++ b/mats-websockets/client/dart/test/integration_basic.dart
@@ -1,10 +1,11 @@
 import 'dart:async';
+import 'dart:math' as math;
 
 import 'package:logging/logging.dart';
 import 'package:mats_socket/mats_socket.dart';
 import 'package:test/test.dart';
+
 import 'lib/env.dart';
-import 'dart:math' as math;
 
 void main() {
   configureLogging();
@@ -24,10 +25,7 @@ void main() {
           'DummyAuth:$userId:${expiry.millisecondsSinceEpoch}', expiry, roomForLatencyMillis);
     }
 
-    setUp(() {
-      matsSocket = MatsSocket('TestApp', '1.2.3', serverUris);
-      _logger.info('Created MatsSocket instance [${matsSocket.matsSocketInstanceId}]');
-    });
+    setUp(() => matsSocket = createMatsSocket());
 
     tearDown(() async  {
       await matsSocket.close('Test done');

--- a/mats-websockets/client/dart/test/integration_connect.dart
+++ b/mats-websockets/client/dart/test/integration_connect.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:logging/logging.dart';
 import 'package:mats_socket/mats_socket.dart';
 import 'package:test/test.dart';
+
 import 'lib/env.dart';
 
 void main() {
@@ -22,13 +23,11 @@ void main() {
           'DummyAuth:$userId:${expiry.millisecondsSinceEpoch}', expiry, roomForLatencyMillis);
     }
 
-    setUp(() {
-      matsSocket = MatsSocket('TestApp', '1.2.3', serverUris);
-      _logger.info('Created MatsSocket instance [${matsSocket.matsSocketInstanceId}]');
-    });
+    setUp(() => matsSocket = createMatsSocket());
 
     tearDown(() async  {
       await matsSocket.close('Test done');
+      _logger.info('=========== Closed MatsSocket [${matsSocket?.matsSocketInstanceId}] ===========');
     });
 
     /*

--- a/mats-websockets/client/dart/test/integration_listeners.dart
+++ b/mats-websockets/client/dart/test/integration_listeners.dart
@@ -1,11 +1,12 @@
 import 'dart:async';
+import 'dart:math' as math;
 
 import 'package:logging/logging.dart';
 import 'package:mats_socket/mats_socket.dart';
 import 'package:mats_socket/src/InitiationProcessedEvent.dart';
 import 'package:test/test.dart';
+
 import 'lib/env.dart';
-import 'dart:math' as math;
 
 void main() {
   configureLogging();
@@ -25,13 +26,11 @@ void main() {
           'DummyAuth:$userId:${expiry.millisecondsSinceEpoch}', expiry, roomForLatencyMillis);
     }
 
-    setUp(() {
-      matsSocket = MatsSocket('TestApp', '1.2.3', serverUris);
-      _logger.info('Created MatsSocket instance [${matsSocket.matsSocketInstanceId}]');
-    });
+    setUp(() => matsSocket = createMatsSocket());
 
     tearDown(() async  {
       await matsSocket.close('Test done');
+      _logger.info('=========== Closed MatsSocket [${matsSocket?.matsSocketInstanceId}] ===========');
     });
 
     // TODO: Check ConnectionEventListeners, including matsSocket.state

--- a/mats-websockets/client/dart/test/integration_listeners.dart
+++ b/mats-websockets/client/dart/test/integration_listeners.dart
@@ -154,7 +154,7 @@ void main() {
 
       Future runRequestTest(bool includeStash) async {
         var initiationProcessedEvent = Completer<InitiationProcessedEvent>();
-        var receivedCompleter = Completer<ReceivedEvent>();
+        var receivedCompleter = Completer<ReceivedEvent>.sync();
         var repliedMessageEvent = Completer<MessageEvent>();
         var traceId = 'InitiationProcessedEvent_request_${id(6)}';
         var msg = {'string': 'The Strange', 'number': math.e};

--- a/mats-websockets/client/dart/test/integration_pubsub.dart
+++ b/mats-websockets/client/dart/test/integration_pubsub.dart
@@ -2,10 +2,9 @@ import 'dart:async';
 
 import 'package:logging/logging.dart';
 import 'package:mats_socket/mats_socket.dart';
-import 'package:mats_socket/src/InitiationProcessedEvent.dart';
 import 'package:test/test.dart';
+
 import 'lib/env.dart';
-import 'dart:math' as math;
 
 void main() {
   configureLogging();
@@ -25,13 +24,11 @@ void main() {
           'DummyAuth:$userId:${expiry.millisecondsSinceEpoch}', expiry, roomForLatencyMillis);
     }
 
-    setUp(() {
-      matsSocket = MatsSocket('TestApp', '1.2.3', serverUris);
-      _logger.info('Created MatsSocket instance [${matsSocket.matsSocketInstanceId}]');
-    });
+    setUp(() => matsSocket = createMatsSocket());
 
     tearDown(() async  {
       await matsSocket.close('Test done');
+      _logger.info('=========== Closed MatsSocket [${matsSocket?.matsSocketInstanceId}] ===========');
     });
 
     group('reconnect', () {

--- a/mats-websockets/client/dart/test/lib/env.dart
+++ b/mats-websockets/client/dart/test/lib/env.dart
@@ -1,8 +1,38 @@
+import 'package:mats_socket/mats_socket.dart';
 import 'package:mats_socket/src/ConnectionEvent.dart';
+import 'package:logging/logging.dart';
 
+import 'package:test_api/src/backend/invoker.dart' show Invoker;
 import 'env_html.dart' if (dart.library.io) 'env_io.dart' as delegate;
 
-void configureLogging() => delegate.configureLogging();
+var logContext = 'none';
+
+/// Helper class to configure dart logging to print to stdout.
+void configureLogging() {
+  Logger.root.level = delegate.logLevel();
+
+  print('Setting log level to ${Logger.root.level}');
+
+  Logger.root.onRecord.listen((LogRecord rec) {
+    print('${rec.time.toIso8601String()} ${rec.level.name} ${rec.loggerName.padRight(24)} |$logContext| ${rec.message}');
+    if (rec.error != null) {
+      print('\tError: ${rec.error}');
+    }
+    if (rec.stackTrace != null) {
+      print(rec.stackTrace);
+    }
+  });
+}
+
+MatsSocket createMatsSocket() {
+  var matsSocket = MatsSocket('TestApp', '1.2.3', delegate.loadServerUris());
+  logContext = matsSocket.matsSocketInstanceId;
+  // Print rather than log the mats socket creation, so that the start of each test
+  // is marked clearly in the logs
+  print('=========== Created MatsSocket [${matsSocket.matsSocketInstanceId}] '
+      'for test [${Invoker?.current?.liveTest?.test?.name}] ===========');
+  return matsSocket;
+}
 
 var serverUris = delegate.loadServerUris();
 

--- a/mats-websockets/client/dart/test/lib/env_html.dart
+++ b/mats-websockets/client/dart/test/lib/env_html.dart
@@ -15,19 +15,6 @@ String reason(ConnectionEvent connectionEvent) {
   return (connectionEvent.webSocketEvent as CloseEvent).reason;
 }
 
-/// Helper class to configure dart logging to print to stdout.
-void configureLogging() {
-
-  print('Setting log level to INFO');
-  Logger.root.level = Level.INFO;
-
-  Logger.root.onRecord.listen((LogRecord rec) {
-    print('${rec.time} ${rec.level.name} ${rec.loggerName.padRight(12)} | ${rec.message}');
-    if (rec.error != null) {
-      print('\tError: ${rec.error}');
-    }
-    if (rec.stackTrace != null) {
-      print(rec.stackTrace);
-    }
-  });
+Level logLevel() {
+  return Level.INFO;
 }

--- a/mats-websockets/client/dart/test/lib/env_io.dart
+++ b/mats-websockets/client/dart/test/lib/env_io.dart
@@ -19,28 +19,13 @@ String reason(ConnectionEvent connectionEvent) {
 }
 
 /// Helper class to configure dart logging to print to stdout.
-void configureLogging() {
+Level logLevel() {
   // We can set the log level through the environment variables, which enables
   // setting the level from gradle.
   var envLogLevel = Platform.environment['LOG_LEVEL'] ?? 'INFO';
   switch (envLogLevel) {
-    case 'DEBUG': { Logger.root.level = Level.ALL; }
-    break;
-    case 'INFO': { Logger.root.level = Level.INFO; }
-    break;
-    default: { Logger.root.level = Level.SEVERE; }
-    break;
+    case 'DEBUG': return Level.ALL;
+    case 'INFO': return Level.INFO;
+    default: return Level.SEVERE;
   }
-
-  print('Setting log level to $envLogLevel');
-
-  Logger.root.onRecord.listen((LogRecord rec) {
-    print('${rec.time} ${rec.level.name} ${rec.loggerName.padRight(12)} | ${rec.message}');
-    if (rec.error != null) {
-      print('\tError: ${rec.error}');
-    }
-    if (rec.stackTrace != null) {
-      print(rec.stackTrace);
-    }
-  });
 }

--- a/mats-websockets/dart.gradle
+++ b/mats-websockets/dart.gradle
@@ -75,7 +75,7 @@ task dartTest(dependsOn: startMatsTestWebsocketServer) {
                 platform = project.getProperties()['platform']
             }
             def testFiles = file("$projectDir/client/dart/test").listFiles().findAll { it.name.endsWith(".dart") }
-            args = ['run', 'test'] + testFiles + ['-p', platform]
+            args = ['run', 'test'] + testFiles + ['-p', platform, '--reporter=expanded', '-j', '1']
         }
 
     }


### PR DESCRIPTION
For MatsSocketCloseCode, and the CloseCodes enum, we now handle unknown
close codes by mapping them to an UNKNOWN enum value.

I contribute this material in accordance with the signed SCA.