### PR TITLE
Introduced test verifying shutdown order of MATS components

### DIFF
--- a/mats-spring/src/test/java/com/stolsvik/mats/spring/AbstractFactoryBeanTestBase.java
+++ b/mats-spring/src/test/java/com/stolsvik/mats/spring/AbstractFactoryBeanTestBase.java
@@ -1,0 +1,332 @@
+package com.stolsvik.mats.spring;
+
+import java.util.LinkedHashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Consumer;
+
+import javax.inject.Inject;
+import javax.jms.ConnectionFactory;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.config.AbstractFactoryBean;
+import org.springframework.beans.factory.config.ConstructorArgumentValues;
+import org.springframework.beans.factory.support.BeanDefinitionRegistry;
+import org.springframework.beans.factory.support.GenericBeanDefinition;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.ImportBeanDefinitionRegistrar;
+import org.springframework.core.type.AnnotationMetadata;
+
+import com.stolsvik.mats.MatsEndpoint;
+import com.stolsvik.mats.MatsEndpoint.EndpointConfig;
+import com.stolsvik.mats.MatsEndpoint.ProcessSingleLambda;
+import com.stolsvik.mats.MatsEndpoint.ProcessTerminatorLambda;
+import com.stolsvik.mats.MatsFactory;
+import com.stolsvik.mats.MatsInitiator;
+import com.stolsvik.mats.MatsStage.StageConfig;
+import com.stolsvik.mats.impl.jms.JmsMatsFactory;
+import com.stolsvik.mats.impl.jms.JmsMatsJmsSessionHandler_Pooling;
+import com.stolsvik.mats.serial.json.MatsSerializer_DefaultJson;
+import com.stolsvik.mats.spring.matsfactoryqualifier.AbstractQualificationTest;
+import com.stolsvik.mats.util_activemq.MatsLocalVmActiveMq;
+
+/**
+ * Base class for {@link VerifyShutdownOrderUsingFactoryBeanTest} - we do not use SpringRunner or other frameworks,
+ * but instead do all Spring config ourselves. This so that the testing is as application-like as possible.
+ * <p>
+ * The the beans created in this configuration have been wrapped in a thin shell which replicates the calls straight
+ * down to their respective counter parts. The reason for wrapping, is that we want access and the possibility to track
+ * when the different beans are closed/stopped/destroyed.
+ * <p>
+ * Heavily inspired by {@link AbstractQualificationTest} created by Endre Stølsvik.
+ */
+public class AbstractFactoryBeanTestBase {
+
+    private final Logger log = LoggerFactory.getLogger(this.getClass());
+
+    protected AnnotationConfigApplicationContext _ctx;
+
+    /**
+     * "Singleton" registry which "tracks" which service have been stopped.
+     */
+    protected static StoppedRegistry _stoppedRegistry = new StoppedRegistry();
+
+    protected void startSpring() {
+        long nanosStart = System.nanoTime();
+        log.info("Starting " + this.getClass().getSimpleName() + "!");
+        log.info(" \\- new'ing up AnnotationConfigApplicationContext, giving class [" + this.getClass()
+                .getSimpleName() + "] as base.");
+        _ctx = new AnnotationConfigApplicationContext(DI_MainContext.class);
+        double startTimeMs = (System.nanoTime() - nanosStart) / 1_000_000d;
+        log.info(" \\- done, AnnotationConfigApplicationContext: [" + _ctx + "], took: [" + startTimeMs + " ms].");
+
+        // Since this test is NOT run by the SpringRunner, the instance which this code is running in is not
+        // managed by Spring. That is: JUnit have instantiated one (this), and Spring has instantiated another.
+        // Therefore, manually autowire this which JUnit has instantiated.
+        _ctx.getAutowireCapableBeanFactory().autowireBean(this);
+    }
+
+    protected void stopSpring() {
+        // :: Close Spring.
+        long nanosStart = System.nanoTime();
+        log.info("Stop - closing Spring ApplicationContext.");
+        _ctx.close();
+        log.info("done. took: [" + ((System.nanoTime() - nanosStart) / 1_000_000d) + " ms].");
+    }
+
+    // =============================================== App configuration ==============================================
+
+    /**
+     * Context was extracted into a separate class as the approach utilized inside {@link AbstractQualificationTest}
+     * did not detected the usage of {@link Import} as utilized on {@link DI_MainContext}.
+     */
+    @Configuration
+    @Import(MatsFactoryBeanDefRegistrar.class)
+    @EnableMats
+    public static class DI_MainContext {
+        @Bean
+        protected MatsLocalVmActiveMqVerifiableStopWrapper activeMq1() {
+            return new MatsLocalVmActiveMqVerifiableStopWrapper(MatsLocalVmActiveMq.createInVmActiveMq("activeMq1"),
+                    _stoppedRegistry);
+        }
+
+        @Bean
+        protected ConnectionFactory connectionFactory1(
+                @Qualifier("activeMq1") MatsLocalVmActiveMqVerifiableStopWrapper activeMq1) {
+            return activeMq1.getConnectionFactory();
+        }
+    }
+
+    public static class MatsFactoryBeanDefRegistrar implements ImportBeanDefinitionRegistrar {
+        @Override
+        public void registerBeanDefinitions(AnnotationMetadata importingClassMetadata,
+                BeanDefinitionRegistry registry) {
+            ConstructorArgumentValues constructorArgumentValues = new ConstructorArgumentValues();
+            GenericBeanDefinition matsFactory = new GenericBeanDefinition();
+            matsFactory.setPrimary(true);
+            matsFactory.setBeanClass(MatsMServiceMatsFactory_FactoryBean.class);
+            matsFactory.setConstructorArgumentValues(constructorArgumentValues);
+            registry.registerBeanDefinition("matsFactory", matsFactory);
+        }
+    }
+
+    /**
+     *
+     */
+    public static class MatsMServiceMatsFactory_FactoryBean extends AbstractFactoryBean<MatsFactoryVerifiableStopWrapper> {
+
+        @Inject
+        private ConnectionFactory _connectionFactory;
+
+        public MatsMServiceMatsFactory_FactoryBean() {
+        }
+
+
+        @Override
+        public Class<?> getObjectType() {
+            return MatsFactory.class;
+        }
+
+        @Override
+        protected MatsFactoryVerifiableStopWrapper createInstance() throws Exception {
+            return new MatsFactoryVerifiableStopWrapper(JmsMatsFactory.createMatsFactory_JmsOnlyTransactions("##TEST##",
+                    "##VERSION##",
+                    JmsMatsJmsSessionHandler_Pooling.create(_connectionFactory),
+                    new MatsSerializer_DefaultJson()),
+                    _stoppedRegistry);
+        }
+    }
+
+    // ===============================================================================================================
+
+    /**
+     * Simple class which contains a {@link LinkedList}, since a LinkedList maintain the elements by insertion order
+     * we can be sure that index 0 happened before index 1. This gives us a reason to be reasonable certain that
+     * the elements contained within the list happen in this order.
+     */
+    public static class StoppedRegistry {
+
+        private Map<String, Boolean> _stoppedServices = new LinkedHashMap<>();
+
+        public StoppedRegistry() {
+        }
+
+        public void registerStopped(String clazzName, boolean stopped) {
+            _stoppedServices.put(clazzName, stopped);
+        }
+
+        public Map<String, Boolean> getStoppedServices() {
+            return _stoppedServices;
+        }
+    }
+
+    // ===============================================================================================================
+
+    /**
+     * Wrapper replicating the behavior of {@link JmsMatsFactory} by passing all calls through to the internal
+     * {@link JmsMatsFactory} given to the constructor. The key method is
+     * {@link MatsFactoryVerifiableStopWrapper#stop(int)} which's stops the underlying factory and utilizes a finally
+     * clause to register itself with the {@link StoppedRegistry} that this instance was indeed stopped.
+     */
+    public static class MatsFactoryVerifiableStopWrapper implements MatsFactory {
+
+        private MatsFactory _matsFactory;
+        private StoppedRegistry _stoppedRegistry;
+
+        public MatsFactoryVerifiableStopWrapper(MatsFactory matsFactory,
+                StoppedRegistry stoppedRegistry) {
+            _matsFactory = matsFactory;
+            _stoppedRegistry = stoppedRegistry;
+        }
+
+        @Override
+        public FactoryConfig getFactoryConfig() {
+            return _matsFactory.getFactoryConfig();
+        }
+
+        @Override
+        public <R, S> MatsEndpoint<R, S> staged(String endpointId, Class<R> replyClass, Class<S> stateClass) {
+            return _matsFactory.staged(endpointId, replyClass, stateClass);
+        }
+
+        @Override
+        public <R, S> MatsEndpoint<R, S> staged(String endpointId, Class<R> replyClass, Class<S> stateClass,
+                Consumer<? super EndpointConfig<R, S>> endpointConfigLambda) {
+            return _matsFactory.staged(endpointId, replyClass, stateClass, endpointConfigLambda);
+        }
+
+        @Override
+        public <R, I> MatsEndpoint<R, Void> single(String endpointId, Class<R> replyClass, Class<I> incomingClass,
+                ProcessSingleLambda<R, I> processor) {
+            return _matsFactory.single(endpointId, replyClass, incomingClass, processor);
+        }
+
+        @Override
+        public <R, I> MatsEndpoint<R, Void> single(String endpointId, Class<R> replyClass, Class<I> incomingClass,
+                Consumer<? super EndpointConfig<R, Void>> endpointConfigLambda,
+                Consumer<? super StageConfig<R, Void, I>> stageConfigLambda, ProcessSingleLambda<R, I> processor) {
+            return _matsFactory
+                    .single(endpointId, replyClass, incomingClass, endpointConfigLambda, stageConfigLambda, processor);
+        }
+
+        @Override
+        public <S, I> MatsEndpoint<Void, S> terminator(String endpointId, Class<S> stateClass, Class<I> incomingClass,
+                ProcessTerminatorLambda<S, I> processor) {
+            return _matsFactory.terminator(endpointId, stateClass, incomingClass, processor);
+        }
+
+        @Override
+        public <S, I> MatsEndpoint<Void, S> terminator(String endpointId, Class<S> stateClass, Class<I> incomingClass,
+                Consumer<? super EndpointConfig<Void, S>> endpointConfigLambda,
+                Consumer<? super StageConfig<Void, S, I>> stageConfigLambda, ProcessTerminatorLambda<S, I> processor) {
+            return _matsFactory
+                    .terminator(endpointId, stateClass, incomingClass, endpointConfigLambda, stageConfigLambda,
+                            processor);
+        }
+
+        @Override
+        public <S, I> MatsEndpoint<Void, S> subscriptionTerminator(String endpointId, Class<S> stateClass,
+                Class<I> incomingClass, ProcessTerminatorLambda<S, I> processor) {
+            return _matsFactory.subscriptionTerminator(endpointId, stateClass, incomingClass, processor);
+        }
+
+        @Override
+        public <S, I> MatsEndpoint<Void, S> subscriptionTerminator(String endpointId, Class<S> stateClass,
+                Class<I> incomingClass, Consumer<? super EndpointConfig<Void, S>> endpointConfigLambda,
+                Consumer<? super StageConfig<Void, S, I>> stageConfigLambda, ProcessTerminatorLambda<S, I> processor) {
+            return _matsFactory.subscriptionTerminator(endpointId, stateClass, incomingClass, endpointConfigLambda,
+                    stageConfigLambda, processor);
+        }
+
+        @Override
+        public List<MatsEndpoint<?, ?>> getEndpoints() {
+            return _matsFactory.getEndpoints();
+        }
+
+        @Override
+        public Optional<MatsEndpoint<?, ?>> getEndpoint(String endpointId) {
+            return _matsFactory.getEndpoint(endpointId);
+        }
+
+        @Override
+        public MatsInitiator getDefaultInitiator() {
+            return _matsFactory.getDefaultInitiator();
+        }
+
+        @Override
+        public MatsInitiator getOrCreateInitiator(String name) {
+            return _matsFactory.getOrCreateInitiator(name);
+        }
+
+        @Override
+        public List<MatsInitiator> getInitiators() {
+            return _matsFactory.getInitiators();
+        }
+
+        @Override
+        public void start() {
+            _matsFactory.start();
+        }
+
+        @Override
+        public void holdEndpointsUntilFactoryIsStarted() {
+            _matsFactory.holdEndpointsUntilFactoryIsStarted();
+        }
+
+        @Override
+        public boolean waitForStarted(int timeoutMillis) {
+            return _matsFactory.waitForStarted(timeoutMillis);
+        }
+
+        @Override
+        public boolean stop(int gracefulShutdownMillis) {
+            boolean returnBoolean = false;
+            try {
+                returnBoolean = _matsFactory.stop(gracefulShutdownMillis);
+            }
+            finally {
+                _stoppedRegistry.registerStopped(getClass().getSimpleName(), returnBoolean);
+            }
+            return returnBoolean;
+        }
+    }
+
+    /**
+     * Wrapper containing a {@link MatsLocalVmActiveMq} which contains the {@link ConnectionFactory} utilized by the
+     * created {@link MatsFactory}.
+     */
+    public static class MatsLocalVmActiveMqVerifiableStopWrapper {
+        MatsLocalVmActiveMq _matsLocalVmActiveMq;
+        private StoppedRegistry _stoppedRegistry;
+
+        public MatsLocalVmActiveMqVerifiableStopWrapper(MatsLocalVmActiveMq matsLocalVmActiveMq,
+                StoppedRegistry stoppedRegistry) {
+            _matsLocalVmActiveMq = matsLocalVmActiveMq;
+            _stoppedRegistry = stoppedRegistry;
+        }
+
+        /**
+         * Called by spring life cycle.
+         */
+        public void close() {
+            try {
+                _matsLocalVmActiveMq.close();
+            }
+            finally {
+                _stoppedRegistry.registerStopped(getClass().getSimpleName(), _matsLocalVmActiveMq.getBrokerService().isStopped());
+            }
+        }
+
+        public ConnectionFactory getConnectionFactory() {
+            return _matsLocalVmActiveMq.getConnectionFactory();
+        }
+    }
+
+}

--- a/mats-spring/src/test/java/com/stolsvik/mats/spring/VerifyShutdownOrderUsingFactoryBeanTest.java
+++ b/mats-spring/src/test/java/com/stolsvik/mats/spring/VerifyShutdownOrderUsingFactoryBeanTest.java
@@ -2,10 +2,13 @@ package com.stolsvik.mats.spring;
 
 import java.util.Map;
 
+import javax.inject.Inject;
+
 import org.junit.Assert;
 import org.junit.Test;
 import org.springframework.beans.factory.config.AbstractFactoryBean;
 
+import com.stolsvik.mats.MatsEndpoint;
 import com.stolsvik.mats.MatsFactory;
 
 /**
@@ -18,17 +21,91 @@ import com.stolsvik.mats.MatsFactory;
  */
 public class VerifyShutdownOrderUsingFactoryBeanTest extends AbstractFactoryBeanTestBase {
 
+    /**
+     * Default timeout in milliseconds utilized for methods requiring a specified timeout.
+     *
+     * @see MatsFactory#waitForStarted(int)
+     */
+    private static final int DEFAULT_TIMEOUT_MILLIS = 10_000;
+
+    @Inject
+    private MatsFactory _matsFactory;
+
     @Test
     public void verifyShutdownOrder() {
-        // :: Setup
+        // At this point, the spring context has not been started and "this" has not been autowired.
+        // Thus the injected matsFactory should be NULL.
+        Assert.assertNull(_matsFactory);
+
+        // :: Act - Start up
         startSpring();
 
-        // :: Act
+        // :: Verify - Post start up
+        // Spring context has been started, and autowiring should be complete. Verify that this is in fact the case.
+        Assert.assertNotNull(_matsFactory);
+
+        // Assert that the matsFactory is running. The matsFactory as the act of starting the factory is hooked into
+        // the spring life cycle, thus after executing the startSpring() method the context should be up and running.
+        Assert.assertTrue(_matsFactory.waitForStarted(DEFAULT_TIMEOUT_MILLIS));
+
+        // The factoryConfig will only return "true" if there are any endpoints registered and running. Thus this
+        // first call should result in a return "false".
+        Assert.assertFalse(_matsFactory.getFactoryConfig().isRunning());
+
+        // Register an endpoint for no other purpose than to verify that the MatsFactory is indeed running.
+        MatsEndpoint<String, Void> anEndpoint =
+                _matsFactory.single("anEndpoint", String.class, String.class, (ctx, msg) -> "I do nothing.");
+
+        // Notice that fact that the endpoint will return "true" even though it MIGHT not actually be ready to process
+        // requests. This is because the "isRunning()" method only checks if there are any registered stageProcessors
+        // for the endpoint, and since this is a the create blocks until it has created these there will of course
+        // be registered stage processors on the endpoint even though they might not have completed their start up
+        // routine.
+        Assert.assertTrue(anEndpoint.getEndpointConfig().isRunning());
+
+        // Wait for the endpoint to actually start - If you change the timeout to "1" milliseconds you can observe
+        // the fact that the endpoint hasn't started (Usually works).
+        // We could here assert on this:
+        // Assert.assertFalse(anEndpoint.waitForStarted(1));
+        // To verify this, however, this MIGHT cause the test to be unstable thus I leave this comment here to highlight
+        // the fact that this is observable.
+        Assert.assertTrue(anEndpoint.waitForStarted(DEFAULT_TIMEOUT_MILLIS));
+
+        // Secondary call to the "isRunning()", notice that this of course also returns true.
+        Assert.assertTrue(anEndpoint.getEndpointConfig().isRunning());
+
+        // There is now a 1 endpoint registered within the Factory and this endpoint should be running. Thus
+        // the factory should now indicate that it is indeed running.
+        Assert.assertTrue(_matsFactory.getFactoryConfig().isRunning());
+
+        // :: Act - Shutdown
         stopSpring();
 
-        // :: Verify
+        // :: Verify - Post shutdown
+        // ---- At this point everything should be stopped, lets verify this.
+
+        // Shutting down the MatsFactory as happend when we stopped the springContext should have removed the stage
+        // processors from the endpoint. This means that the "isRunning()" call to the endpoint should now return
+        // "false".
+        Assert.assertFalse(anEndpoint.getEndpointConfig().isRunning());
+
+        // Verify that the endpoint is indeed stopped.
+        Assert.assertTrue(anEndpoint.stop(DEFAULT_TIMEOUT_MILLIS));
+
+        // Verify that the Mats Factory is indeed stopped.
+        Assert.assertTrue(_matsFactory.stop(DEFAULT_TIMEOUT_MILLIS));
+
+        // Notice: The MatsFactory "isRunning()" will now return "false" as even though it as an endpoint within, the
+        // the shutdown of the factory cause all the stageProcessors of the endpoint to be shutdown and removed
+        // from the endpoint.
+
+        Assert.assertEquals(1, _matsFactory.getEndpoints().size());
+        Assert.assertFalse(_matsFactory.getFactoryConfig().isRunning());
+
         Map<String, Boolean> stoppedServices = _stoppedRegistry.getStoppedServices();
 
+        // Assert the order of which the Factory and the underlying JMS broker was shutdown.
+        // Correct order: 1# Factory - 2# Broker.
         Assert.assertEquals(stoppedServices.size(), 2);
         Assert.assertTrue(stoppedServices.containsKey(MatsFactoryVerifiableStopWrapper.class.getSimpleName()));
         Assert.assertTrue(stoppedServices.containsKey(MatsLocalVmActiveMqVerifiableStopWrapper.class.getSimpleName()));

--- a/mats-spring/src/test/java/com/stolsvik/mats/spring/VerifyShutdownOrderUsingFactoryBeanTest.java
+++ b/mats-spring/src/test/java/com/stolsvik/mats/spring/VerifyShutdownOrderUsingFactoryBeanTest.java
@@ -1,0 +1,39 @@
+package com.stolsvik.mats.spring;
+
+import java.util.Map;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.springframework.beans.factory.config.AbstractFactoryBean;
+
+import com.stolsvik.mats.MatsFactory;
+
+/**
+ * The intention of this test is to verify that a {@link MatsFactory} created through the use of a
+ * {@link AbstractFactoryBean} is shutdown BEFORE the {@link javax.jms.ConnectionFactory JMS ConnectionFactory}.
+ * The reason we want to verify that this is true is to ensure that there are no unwanted exceptions being generated
+ * during shutdown, as shutting down the connectionFactory before shutting down the MatsFactory can lead to
+ *
+ * @author Kevin Mc Tiernan, 10-06-2020 - kmctiernan@gmail.com
+ */
+public class VerifyShutdownOrderUsingFactoryBeanTest extends AbstractFactoryBeanTestBase {
+
+    @Test
+    public void verifyShutdownOrder() {
+        // :: Setup
+        startSpring();
+
+        // :: Act
+        stopSpring();
+
+        // :: Verify
+        Map<String, Boolean> stoppedServices = _stoppedRegistry.getStoppedServices();
+
+        Assert.assertEquals(stoppedServices.size(), 2);
+        Assert.assertTrue(stoppedServices.containsKey(MatsFactoryVerifiableStopWrapper.class.getSimpleName()));
+        Assert.assertTrue(stoppedServices.containsKey(MatsLocalVmActiveMqVerifiableStopWrapper.class.getSimpleName()));
+
+        Assert.assertTrue(stoppedServices.get(MatsFactoryVerifiableStopWrapper.class.getSimpleName()));
+        Assert.assertTrue(stoppedServices.get(MatsLocalVmActiveMqVerifiableStopWrapper.class.getSimpleName()));
+    }
+}


### PR DESCRIPTION
* Introduced a test which verifies the shutdown order for a MatsFactory
  and it's respective JMS ConnectionFactory. Specifically in which the
  shutdown order is executed when the MatsFactory is created through the
  use of a FactoryBean.
  The author of MATS has gone to great lengths to ensure that is
  executed in the correct order, namely MatsFactory first then the
  associated JMS ConnectionFactory. This test aims to verify that the
  intention matches the implementation.
  If the two are not stopped in the correct order one risks getting
  unwanted (though not harmfull) exceptions where the MatsFactory is
  attempting to interact with a JMS ConnectionFactory which is no longer
  runnning.

I contribute this material in accordance with Storebrand's signed SCA.