### PR TITLE
Fix unstable Dart test.

### DIFF
--- a/mats-websockets/client/dart/test/integration_push.dart
+++ b/mats-websockets/client/dart/test/integration_push.dart
@@ -241,7 +241,7 @@ void main() {
         // Then set it to none (0 or undefined), which should result in NO debug object from server-initiated messages
         matsSocket.debug = debugOptions;
 
-        var second = matsSocket.send('Test.server.send.thread', traceId, {'number': math.e});
+        await matsSocket.send('Test.server.send.thread', traceId, {'number': math.e});
 
         var msg = await terminator.first;
 


### PR DESCRIPTION
Very rarely, the test 'Server initiated send should NOT have debug
object if user ask for \'undefined\'.' would fail. This was because
there where messages that where not ACKed at the end of the test run,
and thesse would then be rejected at the test end when the MatsSocket
closed.

What would happen in the test, is the following:
 1. We send a message to the server with all debug options enabled
 2. We send another message to the server with all debug options
    disabled. The point of this is that when the server does a push, it
    should use the last debug options that the client sent. This second
    message also triggers a client push.
 3. We then wait on the client for the server push, and verify that its
    content is correct
 4. After verification, the test is done, and we close the MatsSocket
 5. The ACK for the message in step 2 was not yet received, or was in
    the pipeline somewhere but not processed. When MatsSocket closes, it
    also sends a NACK to all outstanding initiations. It is this NACK
    that causes the test to fail.

This fix is to await the ACK in step 2, so that we are sure that all
messages are ACKed before we proceeed to wait for the server side reply.

I contribute this material in accordance with the signed SCA.