### PR TITLE
Improved the version name reported.

### DIFF
--- a/mats-websockets/client/dart/lib/src/MatsSocket.dart
+++ b/mats-websockets/client/dart/lib/src/MatsSocket.dart
@@ -22,7 +22,7 @@ final Logger _logger = Logger('MatsSocket');
 const String ALPHABET = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
 // JSON-non-quoted and visible Alphabet: 92 chars.
 const String JSON_ALPHABET = '!#\$%&\'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[]^_`abcdefghijklmnopqrstuvwxyz{|}~';
-const String CLIENT_LIB_NAME_AND_VERSION = 'MatsSocket.dart,v0.14.3;';
+const String CLIENT_LIB_NAME_AND_VERSION = 'MatsSocket.dart,v0.14.3';
 
 
 typedef SessionClosedEventListener = Function(MatsSocketCloseEvent);
@@ -1284,7 +1284,7 @@ class MatsSocket {
           type: MessageType.HELLO,
           appName: appName,
           appVersion: appVersion,
-          clientLibAndVersion: '$CLIENT_LIB_NAME_AND_VERSION; User-Agent: ${platform.userAgent}',
+          clientLibAndVersion: '$CLIENT_LIB_NAME_AND_VERSION; ${platform.version}',
           authorization: _authorization
           // This is guaranteed to be in place and valid, see above
       );

--- a/mats-websockets/client/dart/lib/src/MatsSocketPlatform.dart
+++ b/mats-websockets/client/dart/lib/src/MatsSocketPlatform.dart
@@ -29,7 +29,7 @@ abstract class MatsSocketPlatform {
 
   WebSocket connect(Uri webSocketUri, String protocol, String authorization);
 
-  String get userAgent;
+  String get version;
 
   ConnectResult sendAuthorizationHeader(Uri websocketUri, String authorization);
 

--- a/mats-websockets/client/dart/lib/src/MatsSocketPlatformHtml.dart
+++ b/mats-websockets/client/dart/lib/src/MatsSocketPlatformHtml.dart
@@ -23,7 +23,7 @@ class MatsSocketPlatformHtml extends MatsSocketPlatform {
   }
 
   @override
-  String get userAgent => html.window.navigator.userAgent;
+  String get version => html.window.navigator.userAgent;
 
   @override
   ConnectResult sendAuthorizationHeader(Uri websocketUri, String authorization) {

--- a/mats-websockets/client/dart/lib/src/MatsSocketPlatformNative.dart
+++ b/mats-websockets/client/dart/lib/src/MatsSocketPlatformNative.dart
@@ -36,19 +36,16 @@ class MatsSocketPlatformNative extends MatsSocketPlatform {
   }
 
   @override
-  String get userAgent {
+  String get version {
     final osName = io.Platform.operatingSystem;
-    final osVersion = io.Platform.operatingSystemVersion;
+    final osVersion = io.Platform.operatingSystemVersion
+    // We want to skip anything before the first digit, under the assumption that the first digit is the start of
+    // the version number. On OS X the os version starts with "Darwin 20.2.0", so this would strip out the Darwin part.
+    // In addition, we don't want to include ; or any characters following that. We use ; as our own seperator between
+    // various version parts.
+        .replaceAllMapped(RegExp(r'^[^\d]+([^;]+).*'), (match) => match.group(1));
     final dartVersion = io.Platform.version;
-    String platform;
-    if (io.Platform.isIOS) {
-      platform = 'IOS';
-    } else if (io.Platform.isIOS) {
-      platform = 'Android';
-    } else {
-      platform = 'DartVM';
-    }
-    return '${platform} (dart: ${dartVersion}, name: ${osName}, version: ${osVersion})';
+    return '${osName},v${osVersion}; dart:v${dartVersion}';
   }
 
   @override

--- a/mats-websockets/client/dart/test/lib/MatsSocketTransportMock.dart
+++ b/mats-websockets/client/dart/test/lib/MatsSocketTransportMock.dart
@@ -77,7 +77,7 @@ class MatsSocketTransportMock extends MatsSocketPlatform {
   }
 
   @override
-  String get userAgent => 'UnitTest userAgent';
+  String get version => 'UnitTest version';
 
 }
 

--- a/mats-websockets/client/dart/test/platform_test.dart
+++ b/mats-websockets/client/dart/test/platform_test.dart
@@ -11,8 +11,21 @@ void main() {
       MatsSocketPlatform.create();
     });
 
-    test('Able to access user agent', () {
-      expect(MatsSocketPlatform.create().userAgent, isNotNull);
+    test('Able to access version', () {
+      expect(MatsSocketPlatform.create().version, isNotNull);
+    });
+
+    test('Version contains dart version', () {
+      expect(MatsSocketPlatform.create().version, contains('; dart:v'));
+    });
+
+    test('Only a single ; in the version, seperating OS and Dart version', () {
+      // 2 parts, the OS part and the Dart part
+      expect(MatsSocketPlatform.create().version.split(RegExp('; ')), hasLength(2));
+    });
+
+    test('OS Version starts with a digit', () {
+      expect(MatsSocketPlatform.create().version, matches(RegExp(r'^\w+,v\d+.*')));
     });
 
   });


### PR DESCRIPTION
It now better formats the OS and Dart version, ensuring that we can
split on ;, and that each token is a name followed by, then v and a
version.

I contribute this material in accordance with the signed SCA.