### PR TITLE
OsVersion is now used directly, with ; replaced with :

### DIFF
--- a/mats-websockets/client/dart/lib/src/MatsSocketPlatformNative.dart
+++ b/mats-websockets/client/dart/lib/src/MatsSocketPlatformNative.dart
@@ -37,15 +37,14 @@ class MatsSocketPlatformNative extends MatsSocketPlatform {
 
   @override
   String get version {
-    final osName = io.Platform.operatingSystem;
-    final osVersion = io.Platform.operatingSystemVersion
-    // We want to skip anything before the first digit, under the assumption that the first digit is the start of
-    // the version number. On OS X the os version starts with "Darwin 20.2.0", so this would strip out the Darwin part.
-    // In addition, we don't want to include ; or any characters following that. We use ; as our own seperator between
-    // various version parts.
-        .replaceAllMapped(RegExp(r'^[^\d]+([^;]+).*'), (match) => match.group(1));
-    final dartVersion = io.Platform.version;
-    return '${osName},v${osVersion}; dart:v${dartVersion}';
+    // Since we are using ';' to split the pieces, we cannot allow its presence in other elements of the
+    // version string. Also, ',' is used to split the name and version, thus that cannot be a part of the
+    // name. For the name, we replace both with '|' (unlikely to ever happen), while for the version, we
+    // replace ';' with ','.
+    final osName = io.Platform.operatingSystem.replaceAll(RegExp('[;,]'), '|');
+    final osVersion = io.Platform.operatingSystemVersion.replaceAll(RegExp(';'), ',');
+    final dartVersion = io.Platform.version.replaceAll(RegExp(';'), ',');
+    return '${osName},v${osVersion}; dart,v${dartVersion}';
   }
 
   @override

--- a/mats-websockets/client/dart/test/platform_test.dart
+++ b/mats-websockets/client/dart/test/platform_test.dart
@@ -16,16 +16,12 @@ void main() {
     });
 
     test('Version contains dart version', () {
-      expect(MatsSocketPlatform.create().version, contains('; dart:v'));
+      expect(MatsSocketPlatform.create().version, contains('; dart,v'));
     });
 
-    test('Only a single ; in the version, seperating OS and Dart version', () {
+    test('Only a single ; in the version, separating OS and Dart version', () {
       // 2 parts, the OS part and the Dart part
       expect(MatsSocketPlatform.create().version.split(RegExp('; ')), hasLength(2));
-    });
-
-    test('OS Version starts with a digit', () {
-      expect(MatsSocketPlatform.create().version, matches(RegExp(r'^\w+,v\d+.*')));
     });
 
   });


### PR DESCRIPTION
I contribute this material in accordance with the signed SCA.