### PR TITLE
TraceId concat: Use same number for checking max and when getting sub…

### DIFF
--- a/mats-impl-jms/src/main/java/com/stolsvik/mats/impl/jms/JmsMatsInitiator.java
+++ b/mats-impl-jms/src/main/java/com/stolsvik/mats/impl/jms/JmsMatsInitiator.java
@@ -365,7 +365,7 @@ class JmsMatsInitiator<Z> implements MatsInitiator, JmsMatsTxContextKey, JmsMats
         else {
             // -> Yes, too many - creating a "traceId" reflecting cropping.
             collectedTraceIds = "<cropped,numTraceIds:" + collected.size() + ">;"
-                    + String.join(";", collected.subList(0, 20))
+                    + String.join(";", collected.subList(0, 15))
                     + ";...";
         }
         MDC.put(MDC_TRACE_ID, collectedTraceIds);


### PR DESCRIPTION
…List

This causes an error when trying to concat between 16 and 19 traceIds.